### PR TITLE
fix: spread when pushing babel plugins from transformOptions

### DIFF
--- a/src/babel.ts
+++ b/src/babel.ts
@@ -31,7 +31,7 @@ export default function transform (opts: TransformOptions): TRANSFORM_RESULT {
   }
 
   if (opts.babel && Array.isArray(opts.babel.plugins)) {
-    _opts.plugins?.push(opts.babel.plugins)
+    _opts.plugins?.push(...opts.babel.plugins)
   }
 
   try {


### PR DESCRIPTION
Without the spread the following error will be logged:
```
[jiti] Error: .plugins[4][1] must be an object, false, or undefined
```