### PR TITLE
fix: use inlined import meta plugin to inject url

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "acorn": "latest",
     "babel-plugin-dynamic-import-node": "latest",
     "babel-plugin-parameter-decorator": "latest",
-    "babel-plugin-transform-import-meta": "latest",
     "create-require": "latest",
     "cross-env": "latest",
     "destr": "latest",

--- a/src/babel.ts
+++ b/src/babel.ts
@@ -1,9 +1,6 @@
-import { pathToFileURL } from 'url'
-import { smart } from '@babel/template'
-import type { NodePath, PluginObj } from '@babel/core'
-import type { Statement, MemberExpression } from '@babel/types'
 import { transformSync, TransformOptions as BabelTransformOptions } from '@babel/core'
 import { TransformOptions, TRANSFORM_RESULT } from './types'
+import { TransformImportMetaPlugin } from './plugins/babel-plugin-transform-import-meta'
 
 export default function transform (opts: TransformOptions): TRANSFORM_RESULT {
   const _opts: BabelTransformOptions = {
@@ -52,46 +49,6 @@ export default function transform (opts: TransformOptions): TRANSFORM_RESULT {
         code: err.code?.replace('BABEL_', '').replace('PARSE_ERROR', 'ParseError'),
         message: err.message?.replace('/: ', '').replace(/\(.+\)\s*$/, '')
       })
-    }
-  }
-}
-
-// https://github.com/javiertury/babel-plugin-transform-import-meta/blob/master/src/index.ts
-const TransformImportMetaPlugin = (opts: { filename?: string }): PluginObj => {
-  return {
-    name: 'transform-import-meta',
-    visitor: {
-      Program (path) {
-        const metas: Array<NodePath<MemberExpression>> = []
-
-        path.traverse({
-          MemberExpression (memberExpPath) {
-            const { node } = memberExpPath
-
-            if (
-              node.object.type === 'MetaProperty' &&
-              node.object.meta.name === 'import' &&
-              node.object.property.name === 'meta' &&
-              node.property.type === 'Identifier' &&
-              node.property.name === 'url'
-            ) {
-              metas.push(memberExpPath)
-            }
-          }
-        })
-
-        if (metas.length === 0) {
-          return
-        }
-
-        for (const meta of metas) {
-          meta.replaceWith(smart.ast`${
-            opts.filename
-              ? JSON.stringify(pathToFileURL(opts.filename))
-              : "require('url').pathToFileURL(__filename).toString()"
-          }` as Statement)
-        }
-      }
     }
   }
 }

--- a/src/babel.ts
+++ b/src/babel.ts
@@ -1,3 +1,7 @@
+import { pathToFileURL } from 'url'
+import { smart } from '@babel/template'
+import type { NodePath, PluginObj } from '@babel/core'
+import type { Statement, MemberExpression } from '@babel/types'
 import { transformSync, TransformOptions as BabelTransformOptions } from '@babel/core'
 import { TransformOptions, TRANSFORM_RESULT } from './types'
 
@@ -13,7 +17,7 @@ export default function transform (opts: TransformOptions): TRANSFORM_RESULT {
     plugins: [
       [require('@babel/plugin-transform-modules-commonjs'), { allowTopLevelThis: true }],
       [require('babel-plugin-dynamic-import-node'), { noInterop: true }],
-      [require('babel-plugin-transform-import-meta')],
+      [TransformImportMetaPlugin, { filename: opts.filename }],
       [require('@babel/plugin-syntax-class-properties')]
     ]
   }
@@ -48,6 +52,46 @@ export default function transform (opts: TransformOptions): TRANSFORM_RESULT {
         code: err.code?.replace('BABEL_', '').replace('PARSE_ERROR', 'ParseError'),
         message: err.message?.replace('/: ', '').replace(/\(.+\)\s*$/, '')
       })
+    }
+  }
+}
+
+// https://github.com/javiertury/babel-plugin-transform-import-meta/blob/master/src/index.ts
+const TransformImportMetaPlugin = (opts: { filename?: string }): PluginObj => {
+  return {
+    name: 'transform-import-meta',
+    visitor: {
+      Program (path) {
+        const metas: Array<NodePath<MemberExpression>> = []
+
+        path.traverse({
+          MemberExpression (memberExpPath) {
+            const { node } = memberExpPath
+
+            if (
+              node.object.type === 'MetaProperty' &&
+              node.object.meta.name === 'import' &&
+              node.object.property.name === 'meta' &&
+              node.property.type === 'Identifier' &&
+              node.property.name === 'url'
+            ) {
+              metas.push(memberExpPath)
+            }
+          }
+        })
+
+        if (metas.length === 0) {
+          return
+        }
+
+        for (const meta of metas) {
+          meta.replaceWith(smart.ast`${
+            opts.filename
+              ? JSON.stringify(pathToFileURL(opts.filename))
+              : "require('url').pathToFileURL(__filename).toString()"
+          }` as Statement)
+        }
+      }
     }
   }
 }

--- a/src/jiti.ts
+++ b/src/jiti.ts
@@ -29,7 +29,7 @@ const defaults: JITIOptions = {
   sourceMaps: _EnvSourceMaps !== undefined ? !!_EnvSourceMaps : false,
   interopDefault: false,
   esmResolve: _EnvESMResolve || false,
-  cacheVersion: '6',
+  cacheVersion: '7',
   legacy: lt(process.version || '0.0.0', '14.0.0'),
   extensions: ['.js', '.mjs', '.cjs', '.ts']
 }

--- a/src/plugins/babel-plugin-transform-import-meta.ts
+++ b/src/plugins/babel-plugin-transform-import-meta.ts
@@ -1,0 +1,43 @@
+import { pathToFileURL } from 'url'
+import { smart } from '@babel/template'
+import type { NodePath, PluginObj } from '@babel/core'
+import type { Statement, MemberExpression } from '@babel/types'
+
+// Based on https://github.com/javiertury/babel-plugin-transform-import-meta/blob/master/src/index.ts v2.1.1 (MIT License)
+export function TransformImportMetaPlugin(opts: { filename?: string }): PluginObj {
+  return {
+    name: 'transform-import-meta',
+    visitor: {
+      Program(path) {
+        const metas: Array<NodePath<MemberExpression>> = []
+
+        path.traverse({
+          MemberExpression(memberExpPath) {
+            const { node } = memberExpPath
+
+            if (
+              node.object.type === 'MetaProperty' &&
+              node.object.meta.name === 'import' &&
+              node.object.property.name === 'meta' &&
+              node.property.type === 'Identifier' &&
+              node.property.name === 'url'
+            ) {
+              metas.push(memberExpPath)
+            }
+          }
+        })
+
+        if (metas.length === 0) {
+          return
+        }
+
+        for (const meta of metas) {
+          meta.replaceWith(smart.ast`${opts.filename
+            ? JSON.stringify(pathToFileURL(opts.filename))
+            : "require('url').pathToFileURL(__filename).toString()"
+            }` as Statement)
+        }
+      }
+    }
+  }
+}

--- a/src/plugins/babel-plugin-transform-import-meta.ts
+++ b/src/plugins/babel-plugin-transform-import-meta.ts
@@ -4,7 +4,8 @@ import type { NodePath, PluginObj } from '@babel/core'
 import type { Statement, MemberExpression } from '@babel/types'
 
 // Based on https://github.com/javiertury/babel-plugin-transform-import-meta/blob/master/src/index.ts v2.1.1 (MIT License)
-export function TransformImportMetaPlugin (opts: { filename?: string }) {
+// Modification: Inlines resolved filename into the code when possible instead of injecting a require
+export function TransformImportMetaPlugin (_ctx: any, opts: { filename?: string }) {
   return <PluginObj> {
     name: 'transform-import-meta',
     visitor: {

--- a/src/plugins/babel-plugin-transform-import-meta.ts
+++ b/src/plugins/babel-plugin-transform-import-meta.ts
@@ -4,15 +4,15 @@ import type { NodePath, PluginObj } from '@babel/core'
 import type { Statement, MemberExpression } from '@babel/types'
 
 // Based on https://github.com/javiertury/babel-plugin-transform-import-meta/blob/master/src/index.ts v2.1.1 (MIT License)
-export function TransformImportMetaPlugin(opts: { filename?: string }): PluginObj {
-  return {
+export function TransformImportMetaPlugin (opts: { filename?: string }) {
+  return <PluginObj> {
     name: 'transform-import-meta',
     visitor: {
-      Program(path) {
+      Program (path) {
         const metas: Array<NodePath<MemberExpression>> = []
 
         path.traverse({
-          MemberExpression(memberExpPath) {
+          MemberExpression (memberExpPath) {
             const { node } = memberExpPath
 
             if (

--- a/yarn.lock
+++ b/yarn.lock
@@ -307,7 +307,7 @@
     "@babel/helper-validator-option" "^7.16.7"
     "@babel/plugin-transform-typescript" "^7.16.7"
 
-"@babel/template@^7.16.7", "@babel/template@^7.4.4":
+"@babel/template@^7.16.7":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.16.7.tgz#8d126c8701fde4d66b264b3eba3d96f07666d155"
   integrity sha512-I8j/x8kHUrbYRTUxXrrMbfCa7jxkE7tZre39x3kjr9hvI82cK1FfqLygotcWN5kdPGWcLdWMHpSBavse5tWw3w==
@@ -889,14 +889,6 @@ babel-plugin-parameter-decorator@latest:
   version "1.0.16"
   resolved "https://registry.yarnpkg.com/babel-plugin-parameter-decorator/-/babel-plugin-parameter-decorator-1.0.16.tgz#1c889c3a1f3bbf03801fcbc2e95b8bae7468df3f"
   integrity sha512-yUT2WPTUg1JaPmRGRSF557m1HJ9vdFQInRWOkiOyO5a9HhqlXffJu+fQ2xd5+qU/35ICMrrk9eWKsHCairKA9w==
-
-babel-plugin-transform-import-meta@latest:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-import-meta/-/babel-plugin-transform-import-meta-2.1.0.tgz#7ba03fb60800975c8546861f8d88b4e66ce097fc"
-  integrity sha512-pcjJWEARZNgqPdXaBU9xA5oC9dYrgvn8Ya3XusQUuIuRB/3NEVXMI3bnzOJG1GaWWmFzp9OyDnp1w3aZo7VCRQ==
-  dependencies:
-    "@babel/template" "^7.4.4"
-    tslib "^2.2.0"
 
 balanced-match@^1.0.0:
   version "1.0.2"
@@ -3652,7 +3644,7 @@ tslib@^1.8.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.2.0, tslib@latest:
+tslib@latest:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==


### PR DESCRIPTION
Previously we were replacing `import.meta.url` with `require('url').pathToFileURL(__filename).toString()`. This was of course fine unless it was a native ESM file which was _polyfilling_ `__filename`, `require`, etc., in which case something like this was generated:

```js
const _require2 = (0, _module.createRequire)(_require2('url').pathToFileURL(_filename).toString());
```

... which would of course fail.

Ideally we'd like not to transpile native ESM, but this does fix the issue by inlining the actual filename rather than a `require` call, and it gracefully falls back to previous behaviour if the filename isn't present.