### PR TITLE
chore: update development section

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,13 +129,11 @@ List of modules (within `node_modules`) to transform them regardless of syntax.
 
 ## Development
 
-
 - Clone this repository
 - Enable [Corepack](https://github.com/nodejs/corepack) using `corepack enable` (use `npm i -g corepack` for Node.js < 16.10)
 - Install dependencies using `pnpm install`
 - Run `pnpm dev`
 - Run `pnpm jiti ./test/path/to/file.ts`
-
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ List of modules (within `node_modules`) to transform them regardless of syntax.
 ## Development
 
 - Clone this repository
-- Enable [Corepack](https://github.com/nodejs/corepack) using `corepack enable` (use `npm i -g corepack` for Node.js < 16.10)
+- Enable [Corepack](https://github.com/nodejs/corepack) using `corepack enable`
 - Install dependencies using `pnpm install`
 - Run `pnpm dev`
 - Run `pnpm jiti ./test/path/to/file.ts`

--- a/README.md
+++ b/README.md
@@ -129,11 +129,13 @@ List of modules (within `node_modules`) to transform them regardless of syntax.
 
 ## Development
 
-- Clone Repo
-- Run `yarn`
-- Run `yarn build`
-- Run `yarn dev`
-- Run `yarn jiti ./test/path/to/file.ts`
+
+- Clone this repository
+- Enable [Corepack](https://github.com/nodejs/corepack) using `corepack enable` (use `npm i -g corepack` for Node.js < 16.10)
+- Install dependencies using `pnpm install`
+- Run `pnpm dev`
+- Run `pnpm jiti ./test/path/to/file.ts`
+
 
 ## License
 


### PR DESCRIPTION
After migration to pnpm (https://github.com/unjs/jiti/pull/69) readme wasn't update