### PR TITLE
Added Example for debugging with Visual Studio Code and source maps

### DIFF
--- a/examples/vscode-debug/.vscode/launch.json
+++ b/examples/vscode-debug/.vscode/launch.json
@@ -1,0 +1,29 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Debug Typescript",
+      "request": "launch",
+      "cwd": "${workspaceFolder}",
+      "program": "${file}",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": [
+        "jiti"
+      ],
+      "type": "node",
+      "env": {
+        "JITI_SOURCE_MAPS": "true",
+        // When source maps is enabled
+        // we need to disable the cache to prevent it interfering
+        "JITI_CACHE": "false"
+      },
+      "smartStep": true,
+      "resolveSourceMapLocations": [
+        "${workspaceFolder}/**",
+        "!**/node_modules/**",
+	      // If you have problems with sourcemaps in a monorepo, try adding the directories here
+        // "${workspaceFolder}/../some-directory/**",
+      ]
+    }
+  ]
+}

--- a/examples/vscode-debug/.vscode/launch.json
+++ b/examples/vscode-debug/.vscode/launch.json
@@ -7,9 +7,7 @@
       "cwd": "${workspaceFolder}",
       "program": "${file}",
       "runtimeExecutable": "pnpm",
-      "runtimeArgs": [
-        "jiti"
-      ],
+      "runtimeArgs": ["jiti"],
       "type": "node",
       "env": {
         "JITI_SOURCE_MAPS": "true",
@@ -20,8 +18,8 @@
       "smartStep": true,
       "resolveSourceMapLocations": [
         "${workspaceFolder}/**",
-        "!**/node_modules/**",
-	      // If you have problems with sourcemaps in a monorepo, try adding the directories here
+        "!**/node_modules/**"
+        // If you have problems with sourcemaps in a monorepo, try adding the directories here
         // "${workspaceFolder}/../some-directory/**",
       ]
     }

--- a/examples/vscode-debug/README.md
+++ b/examples/vscode-debug/README.md
@@ -1,10 +1,10 @@
 # Readme
 
 This is an example of debugging / adding breakpoints for Jiti launched typescript files
-using Visual Studio Code
+using Visual Studio Code with source maps.
 
 The launch.json assumes pnpm is being used as the package manager
-In order for this to work
+In order for this to work:
 
-  * `JITI_SOURCE_MAPS` should be enabled within launch.json
-  * `JITI_CACHE` should be disabled within launch.json
+- `JITI_SOURCE_MAPS` should be enabled within launch.json
+- `JITI_CACHE` should be disabled within launch.json

--- a/examples/vscode-debug/README.md
+++ b/examples/vscode-debug/README.md
@@ -1,0 +1,10 @@
+# Readme
+
+This is an example of debugging / adding breakpoints for Jiti launched typescript files
+using Visual Studio Code
+
+The launch.json assumes pnpm is being used as the package manager
+In order for this to work
+
+  * `JITI_SOURCE_MAPS` should be enabled within launch.json
+  * `JITI_CACHE` should be disabled within launch.json

--- a/examples/vscode-debug/package.json
+++ b/examples/vscode-debug/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "vscode-debug-example",
+  "private": true,
+  "dependencies": {
+    "jiti": "^1.16.1"
+  },
+  "devDependencies": {
+    "@types/node": "^18.11.18",
+    "typescript": "^4.9.4"
+  }
+}

--- a/examples/vscode-debug/pnpm-lock.yaml
+++ b/examples/vscode-debug/pnpm-lock.yaml
@@ -1,0 +1,30 @@
+lockfileVersion: 5.4
+
+specifiers:
+  '@types/node': ^18.11.18
+  jiti: ^1.16.1
+  typescript: ^4.9.4
+
+dependencies:
+  jiti: 1.16.2
+
+devDependencies:
+  '@types/node': 18.11.18
+  typescript: 4.9.4
+
+packages:
+
+  /@types/node/18.11.18:
+    resolution: {integrity: sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==}
+    dev: true
+
+  /jiti/1.16.2:
+    resolution: {integrity: sha512-OKBOVWmU3FxDt/UH4zSwiKPuc1nihFZiOD722FuJlngvLz2glX1v2/TJIgoA4+mrpnXxHV6dSAoCvPcYQtoG5A==}
+    hasBin: true
+    dev: false
+
+  /typescript/4.9.4:
+    resolution: {integrity: sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==}
+    engines: {node: '>=4.2.0'}
+    hasBin: true
+    dev: true

--- a/examples/vscode-debug/pnpm-lock.yaml
+++ b/examples/vscode-debug/pnpm-lock.yaml
@@ -1,7 +1,7 @@
 lockfileVersion: 5.4
 
 specifiers:
-  '@types/node': ^18.11.18
+  "@types/node": ^18.11.18
   jiti: ^1.16.1
   typescript: ^4.9.4
 
@@ -9,22 +9,30 @@ dependencies:
   jiti: 1.16.2
 
 devDependencies:
-  '@types/node': 18.11.18
+  "@types/node": 18.11.18
   typescript: 4.9.4
 
 packages:
-
   /@types/node/18.11.18:
-    resolution: {integrity: sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==}
+    resolution:
+      {
+        integrity: sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==,
+      }
     dev: true
 
   /jiti/1.16.2:
-    resolution: {integrity: sha512-OKBOVWmU3FxDt/UH4zSwiKPuc1nihFZiOD722FuJlngvLz2glX1v2/TJIgoA4+mrpnXxHV6dSAoCvPcYQtoG5A==}
+    resolution:
+      {
+        integrity: sha512-OKBOVWmU3FxDt/UH4zSwiKPuc1nihFZiOD722FuJlngvLz2glX1v2/TJIgoA4+mrpnXxHV6dSAoCvPcYQtoG5A==,
+      }
     hasBin: true
     dev: false
 
   /typescript/4.9.4:
-    resolution: {integrity: sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==}
-    engines: {node: '>=4.2.0'}
+    resolution:
+      {
+        integrity: sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==,
+      }
+    engines: { node: ">=4.2.0" }
     hasBin: true
     dev: true

--- a/examples/vscode-debug/src/app.ts
+++ b/examples/vscode-debug/src/app.ts
@@ -1,0 +1,7 @@
+
+function printHello() {
+  // Try adding a breakpoint here
+  console.log("hello world!")
+}
+
+printHello()

--- a/examples/vscode-debug/src/app.ts
+++ b/examples/vscode-debug/src/app.ts
@@ -1,7 +1,6 @@
-
 function printHello() {
   // Try adding a breakpoint here
-  console.log("hello world!")
+  console.log("hello world!");
 }
 
-printHello()
+printHello();

--- a/examples/vscode-debug/tsconfig.json
+++ b/examples/vscode-debug/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES6",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "declarationDir": "dist",
+    "declaration": true,
+    "experimentalDecorators": true,
+    "types": ["node"]
+  },
+  "include": ["src"]
+}

--- a/examples/vscode-debug/vscode-debug.code-workspace
+++ b/examples/vscode-debug/vscode-debug.code-workspace
@@ -1,0 +1,10 @@
+{
+  "folders": [
+    {
+      "path": "."
+    },
+  ],
+  "settings": {
+    "typescript.tsdk": "./node_modules/typescript/lib"
+  }
+}


### PR DESCRIPTION
Hi,
It took me a little while to figure out the right combination of options to use when debugging typescript using visual studio code and jiti.
I figured I'd add an example just to make it easier for others.

I noticed that when the cache is enabled, the cached files are not overwritten if the sourcemap option was disabled the first time around but then enabled the second time around when launching a script.
Also disabling the cache seems to be a necessity anyway when debugging with source maps, as I think the sourcemap changes on each run.
