### PR TITLE
fix: prefer require condition first in esm resolve mode

### DIFF
--- a/src/jiti.ts
+++ b/src/jiti.ts
@@ -146,16 +146,22 @@ export default function createJITI(
 
     // Try ESM resolve
     if (opts.esmResolve) {
-      try {
-        resolved = resolvePathSync(id, {
-          url: _url,
-          conditions: ["node", "require", "import"],
-        });
-      } catch (error) {
-        err = error;
-      }
-      if (resolved) {
-        return resolved;
+      const conditionSets = [
+        ["node", "require"],
+        ["node", "import"],
+      ]
+      for (const conditions of conditionSets) {
+        try {
+          resolved = resolvePathSync(id, {
+            url: _url,
+            conditions,
+          });
+        } catch (error) {
+          err = error;
+        }
+        if (resolved) {
+          return resolved;
+        }
       }
     }
 


### PR DESCRIPTION
Jiti internally works with CJS and using MJS build is costly with non native transforms and can lead to issues. 

When a package both cjs and esm exports (most of the unjs packages), jiti should prefer cjs first as is native. However if exports condition (key order matters) is `{ types, import, require }` we first match `import`. Using two condition sets fixes the issue.