### PR TITLE
fix: workaround for pnpm and `TMPDIR`

### DIFF
--- a/src/jiti.ts
+++ b/src/jiti.ts
@@ -1,7 +1,7 @@
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from "fs";
 import { Module, builtinModules } from "module";
 import { performance } from "perf_hooks";
-import { tmpdir, platform } from "os";
+import { platform } from "os";
 import vm from "vm";
 import { fileURLToPath, pathToFileURL } from "url";
 import { dirname, join, basename, extname } from "pathe";
@@ -14,6 +14,7 @@ import { addHook } from "pirates";
 import objectHash from "object-hash";
 import { hasESMSyntax, interopDefault, resolvePathSync } from "mlly";
 import {
+  getOsTmpDir,
   isDir,
   isWritable,
   md5,
@@ -105,7 +106,7 @@ export default function createJITI(
   }
 
   if (opts.cache === true) {
-    opts.cache = join(tmpdir(), "node-jiti");
+    opts.cache = join(getOsTmpDir(), "node-jiti");
   }
   if (opts.cache) {
     try {

--- a/src/jiti.ts
+++ b/src/jiti.ts
@@ -14,7 +14,7 @@ import { addHook } from "pirates";
 import objectHash from "object-hash";
 import { hasESMSyntax, interopDefault, resolvePathSync } from "mlly";
 import {
-  getOsTmpDir,
+  getCacheDir,
   isDir,
   isWritable,
   md5,
@@ -106,7 +106,7 @@ export default function createJITI(
   }
 
   if (opts.cache === true) {
-    opts.cache = join(getOsTmpDir(), "node-jiti");
+    opts.cache = getCacheDir();
   }
   if (opts.cache) {
     try {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,14 +5,18 @@ import { join } from "pathe";
 import type { PackageJson } from "pkg-types";
 
 export function getCacheDir() {
-  let _tmpDir = tmpdir()
+  let _tmpDir = tmpdir();
 
   // Workaround for pnpm setting an incorrect `TMPDIR`.
   // Set `JITI_RESPECT_TMPDIR_ENV` to a truthy value to disable this workaround.
   // https://github.com/pnpm/pnpm/issues/6140
   // https://github.com/unjs/jiti/issues/120
-  if (process.env.TMPDIR && _tmpDir === process.cwd() && !process.env.JITI_RESPECT_TMPDIR_ENV) {
-    const _env = process.env.TMPDIR
+  if (
+    process.env.TMPDIR &&
+    _tmpDir === process.cwd() &&
+    !process.env.JITI_RESPECT_TMPDIR_ENV
+  ) {
+    const _env = process.env.TMPDIR;
     delete process.env.TMPDIR;
     _tmpDir = tmpdir();
     process.env.TMPDIR = _env;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,16 +8,16 @@ import type { PackageJson } from "pkg-types";
 // Set `JITI_TMPDIR_KEEP` to a truthy value to disable this workaround.
 // https://github.com/pnpm/pnpm/issues/6140
 // https://github.com/unjs/jiti/issues/120
-export function getOsTmpDir() {
+export function getCacheDir() {
   if (process.env.JITI_TMPDIR_KEEP) {
-    return tmpdir();
+    return join(tmpdir(), "node-jiti");
   }
 
   const currentTmpDir = process.env.TMPDIR;
   delete process.env.TMPDIR;
-  const osTmpDir = tmpdir();
+  const defaultTmpDir = tmpdir();
   process.env.TMPDIR = currentTmpDir;
-  return osTmpDir;
+  return join(defaultTmpDir, "node-jiti");
 }
 
 export function isDir(filename: string): boolean {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,15 +4,15 @@ import { tmpdir } from "os";
 import { join } from "pathe";
 import type { PackageJson } from "pkg-types";
 
-// Workaround for pnpm setting an incorrect `TMPDIR`.
-// Set `JITI_TMPDIR_KEEP` to a truthy value to disable this workaround.
-// https://github.com/pnpm/pnpm/issues/6140
-// https://github.com/unjs/jiti/issues/120
 export function getCacheDir() {
-  if (process.env.JITI_TMPDIR_KEEP) {
+  if (process.cwd() !== tmpdir() || process.env.JITI_TMPDIR_KEEP) {
     return join(tmpdir(), "node-jiti");
   }
 
+  // Workaround for pnpm setting an incorrect `TMPDIR`.
+  // Set `JITI_TMPDIR_KEEP` to a truthy value to disable this workaround.
+  // https://github.com/pnpm/pnpm/issues/6140
+  // https://github.com/unjs/jiti/issues/120
   const currentTmpDir = process.env.TMPDIR;
   delete process.env.TMPDIR;
   const defaultTmpDir = tmpdir();

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,24 @@
 import { lstatSync, accessSync, constants, readFileSync } from "fs";
 import { createHash } from "crypto";
+import { tmpdir } from "os";
 import { join } from "pathe";
 import type { PackageJson } from "pkg-types";
+
+// Workaround for pnpm setting an incorrect `TMPDIR`.
+// Set `JITI_TMPDIR_KEEP` to a truthy value to disable this workaround.
+// https://github.com/pnpm/pnpm/issues/6140
+// https://github.com/unjs/jiti/issues/120
+export function getOsTmpDir() {
+  if (process.env.JITI_TMPDIR_KEEP) {
+    return tmpdir();
+  }
+
+  const currentTmpDir = process.env.TMPDIR;
+  delete process.env.TMPDIR;
+  const osTmpDir = tmpdir();
+  process.env.TMPDIR = currentTmpDir;
+  return osTmpDir;
+}
 
 export function isDir(filename: string): boolean {
   try {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,19 +5,20 @@ import { join } from "pathe";
 import type { PackageJson } from "pkg-types";
 
 export function getCacheDir() {
-  if (process.cwd() !== tmpdir() || process.env.JITI_TMPDIR_KEEP) {
-    return join(tmpdir(), "node-jiti");
-  }
+  let _tmpDir = tmpdir()
 
   // Workaround for pnpm setting an incorrect `TMPDIR`.
-  // Set `JITI_TMPDIR_KEEP` to a truthy value to disable this workaround.
+  // Set `JITI_RESPECT_TMPDIR_ENV` to a truthy value to disable this workaround.
   // https://github.com/pnpm/pnpm/issues/6140
   // https://github.com/unjs/jiti/issues/120
-  const currentTmpDir = process.env.TMPDIR;
-  delete process.env.TMPDIR;
-  const defaultTmpDir = tmpdir();
-  process.env.TMPDIR = currentTmpDir;
-  return join(defaultTmpDir, "node-jiti");
+  if (process.env.TMPDIR && _tmpDir === process.cwd() && !process.env.JITI_RESPECT_TMPDIR_ENV) {
+    const _env = process.env.TMPDIR
+    delete process.env.TMPDIR;
+    _tmpDir = tmpdir();
+    process.env.TMPDIR = _env;
+  }
+
+  return join(_tmpDir, "node-jiti");
 }
 
 export function isDir(filename: string): boolean {

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -17,10 +17,10 @@ describe("utils", () => {
     });
 
     it("returns the system's TMPDIR when TMPDIR is not set", () => {
-      const originalTmpdir = process.env.TMPDIR
-      delete process.env.TMPDIR
+      const originalTmpdir = process.env.TMPDIR;
+      delete process.env.TMPDIR;
       expect(getCacheDir()).toBe("/tmp/node-jiti");
-      process.env.TMPDIR = originalTmpdir
+      process.env.TMPDIR = originalTmpdir;
     });
 
     it("returns TMPDIR when TMPDIR is not CWD", () => {
@@ -29,13 +29,13 @@ describe("utils", () => {
     });
 
     it("returns the system's TMPDIR when TMPDIR is CWD", () => {
-      vi.stubEnv('TMPDIR', cwd)
+      vi.stubEnv("TMPDIR", cwd);
       expect(getCacheDir()).toBe("/tmp/node-jiti");
     });
 
     it("returns TMPDIR when TMPDIR is CWD and TMPDIR is kept", () => {
-      vi.stubEnv('TMPDIR', cwd)
-      vi.stubEnv('JITI_RESPECT_TMPDIR_ENV', 'true')
+      vi.stubEnv("TMPDIR", cwd);
+      vi.stubEnv("JITI_RESPECT_TMPDIR_ENV", "true");
 
       expect(getCacheDir()).toBe("/cwd/node-jiti");
     });

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -35,7 +35,7 @@ describe("utils", () => {
 
     it("returns TMPDIR when TMPDIR is CWD and TMPDIR is kept", () => {
       vi.stubEnv('TMPDIR', cwd)
-      vi.stubEnv('JITI_TMPDIR_KEEP', 'true')
+      vi.stubEnv('JITI_RESPECT_TMPDIR_ENV', 'true')
 
       expect(getCacheDir()).toBe("/cwd/node-jiti");
     });

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, beforeEach, it, expect, vi } from "vitest";
+
+import { getCacheDir } from "../src/utils";
+
+describe("utils", () => {
+  describe("getCacheDir", () => {
+    const cwd = "/cwd";
+    const notCwd = `${cwd}__NOT__`;
+
+    beforeEach(() => {
+      vi.spyOn(process, "cwd").mockImplementation(() => cwd);
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+      vi.unstubAllEnvs();
+    });
+
+    it("returns the system's TMPDIR when TMPDIR is not set", () => {
+      const originalTmpdir = process.env.TMPDIR
+      delete process.env.TMPDIR
+      expect(getCacheDir()).toBe("/tmp/node-jiti");
+      process.env.TMPDIR = originalTmpdir
+    });
+
+    it("returns TMPDIR when TMPDIR is not CWD", () => {
+      vi.stubEnv("TMPDIR", notCwd);
+      expect(getCacheDir()).toBe("/cwd__NOT__/node-jiti");
+    });
+
+    it("returns the system's TMPDIR when TMPDIR is CWD", () => {
+      vi.stubEnv('TMPDIR', cwd)
+      expect(getCacheDir()).toBe("/tmp/node-jiti");
+    });
+
+    it("returns TMPDIR when TMPDIR is CWD and TMPDIR is kept", () => {
+      vi.stubEnv('TMPDIR', cwd)
+      vi.stubEnv('JITI_TMPDIR_KEEP', 'true')
+
+      expect(getCacheDir()).toBe("/cwd/node-jiti");
+    });
+  });
+});


### PR DESCRIPTION
Resolves #120

Workaround for pnpm setting an incorrect `TMPDIR`. See https://github.com/pnpm/pnpm/issues/6140

Thinking about it a bit more I worry that introducing this workaround also prevents people from making use of their custom `TMPDIR` - if there is one. I think that more people run `nuxt prepare` using pnpm in the respective hook, though, than people set `TMPDIR` themself. So I also added that `JITI_TMPDIR_KEEP` can be set to a truthy value to disable this workaround for people who'd like to keep their `TMPDIR`.