### PR TITLE
fix: use inline require cache to avoid circular dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build": "pnpm clean && cross-env NODE_ENV=production pnpm webpack",
     "clean": "rm -rf dist",
     "dev": "pnpm clean && pnpm webpack --watch",
-    "jiti": "cross-env JITI_DEBUG=1 JITI_CACHE=false ./bin/jiti.js",
+    "jiti": "cross-env JITI_DEBUG=1 JITI_CACHE=false JITI_REQUIRE_CACHE=false ./bin/jiti.js",
     "jiti:legacy": "cross-env JITI_DEBUG=1 npx node@12 ./bin/jiti.js",
     "lint": "eslint --ext .ts,.js . && prettier -c src lib test stubs",
     "release": "pnpm build && pnpm test && changelogen --release && npm publish && git push --follow-tags",

--- a/src/jiti.ts
+++ b/src/jiti.ts
@@ -58,7 +58,7 @@ export default function createJITI(
   _filename: string,
   opts: JITIOptions = {},
   parentModule?: typeof module,
-  requiredModules: Record<string, typeof module> = {}
+  requiredModules?: Record<string, typeof module>
 ): JITI {
   opts = { ...defaults, ...opts };
 
@@ -292,7 +292,7 @@ export default function createJITI(
     }
 
     // Check for CJS cache
-    if (requiredModules[filename]) {
+    if (requiredModules && requiredModules[filename]) {
       return _interopDefault(requiredModules[filename]?.exports);
     }
     if (opts.requireCache && nativeRequire.cache[filename]) {
@@ -348,7 +348,7 @@ export default function createJITI(
         parentModule.children.push(mod);
       }
     }
-    mod.require = createJITI(filename, opts, mod, requiredModules);
+    mod.require = createJITI(filename, opts, mod, requiredModules || {});
 
     // @ts-ignore
     mod.path = dirname(filename);
@@ -357,7 +357,9 @@ export default function createJITI(
     mod.paths = Module._nodeModulePaths(mod.path);
 
     // Set CJS cache before eval
-    requiredModules[filename] = mod;
+    if (requiredModules) {
+      requiredModules[filename] = mod;
+    }
     if (opts.requireCache) {
       nativeRequire.cache[filename] = mod;
     }
@@ -396,7 +398,9 @@ export default function createJITI(
     }
 
     // Remove from required modules cache
-    delete requiredModules[filename];
+    if (requiredModules) {
+      delete requiredModules[filename];
+    }
 
     // Check for parse errors
     if (mod.exports && mod.exports.__JITI_ERROR__) {
@@ -427,7 +431,7 @@ export default function createJITI(
   }
 
   jiti.resolve = _resolve;
-  jiti.cache = opts.requireCache ? nativeRequire.cache : requiredModules;
+  jiti.cache = opts.requireCache ? nativeRequire.cache : {};
   jiti.extensions = nativeRequire.extensions;
   jiti.main = nativeRequire.main;
   jiti.transform = transform;

--- a/test/fixtures/circular/index.js
+++ b/test/fixtures/circular/index.js
@@ -1,4 +1,3 @@
-import { resolve } from 'import-meta-resolve';
 import { withBase } from "./a";
 
 console.log(withBase("Bar"));

--- a/test/fixtures/circular/index.js
+++ b/test/fixtures/circular/index.js
@@ -1,3 +1,4 @@
+import { resolve } from 'import-meta-resolve';
 import { withBase } from "./a";
 
 console.log(withBase("Bar"));


### PR DESCRIPTION
resolves https://github.com/unjs/jiti/issues/124
resolves https://github.com/unjs/c12/issues/58

When `requireCache` is disabled, we still need an object to track circular dependencies. The new object will be passed by `jiti` calls but in same session and invalidated after tree evaluation.