### PR TITLE
fix: resolve Windows paths properly

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   ],
   "scripts": {
     "build": "pnpm clean && cross-env NODE_ENV=production pnpm webpack",
-    "clean": "rm -rf dist",
+    "clean": "rimraf dist",
     "dev": "pnpm clean && pnpm webpack --watch",
     "jiti": "cross-env JITI_DEBUG=1 JITI_CACHE=false JITI_REQUIRE_CACHE=false ./bin/jiti.js",
     "jiti:legacy": "cross-env JITI_DEBUG=1 npx node@12 ./bin/jiti.js",
@@ -65,6 +65,7 @@
     "pkg-types": "^1.0.2",
     "prettier": "^2.8.4",
     "reflect-metadata": "^0.1.13",
+    "rimraf": "^4.4.1",
     "semver": "^7.3.8",
     "std-env": "^3.3.2",
     "terser-webpack-plugin": "^5.3.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,6 +43,7 @@ specifiers:
   pkg-types: ^1.0.2
   prettier: ^2.8.4
   reflect-metadata: ^0.1.13
+  rimraf: ^4.4.1
   semver: ^7.3.8
   std-env: ^3.3.2
   terser-webpack-plugin: ^5.3.7
@@ -97,6 +98,7 @@ devDependencies:
   pkg-types: 1.0.2
   prettier: 2.8.4
   reflect-metadata: 0.1.13
+  rimraf: 4.4.1
   semver: 7.3.8
   std-env: 3.3.2
   terser-webpack-plugin: 5.3.7_webpack@5.76.1
@@ -1472,6 +1474,12 @@ packages:
       concat-map: 0.0.1
     dev: true
 
+  /brace-expansion/2.0.1:
+    resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
+    dependencies:
+      balanced-match: 1.0.2
+    dev: true
+
   /braces/3.0.2:
     resolution: {integrity: sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==}
     engines: {node: '>=8'}
@@ -2587,6 +2595,16 @@ packages:
       path-is-absolute: 1.0.1
     dev: true
 
+  /glob/9.3.4:
+    resolution: {integrity: sha512-qaSc49hojMOv1EPM4EuyITjDSgSKI0rthoHnvE81tcOi1SCVndHko7auqxdQ14eiQG2NDBJBE86+2xIrbIvrbA==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    dependencies:
+      fs.realpath: 1.0.0
+      minimatch: 8.0.3
+      minipass: 4.2.5
+      path-scurry: 1.6.3
+    dev: true
+
   /globals/11.12.0:
     resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
     engines: {node: '>=4'}
@@ -3103,6 +3121,11 @@ packages:
       yallist: 4.0.0
     dev: true
 
+  /lru-cache/7.18.3:
+    resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
+    engines: {node: '>=12'}
+    dev: true
+
   /make-dir/3.1.0:
     resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
     engines: {node: '>=8'}
@@ -3153,6 +3176,13 @@ packages:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
     dependencies:
       brace-expansion: 1.1.11
+    dev: true
+
+  /minimatch/8.0.3:
+    resolution: {integrity: sha512-tEEvU9TkZgnFDCtpnrEYnPsjT7iUx42aXfs4bzmQ5sMA09/6hZY0jeZcGkXyDagiBOvkUjNo8Viom+Me6+2x7g==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    dependencies:
+      brace-expansion: 2.0.1
     dev: true
 
   /minimist/1.2.8:
@@ -3405,6 +3435,14 @@ packages:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
     dev: true
 
+  /path-scurry/1.6.3:
+    resolution: {integrity: sha512-RAmB+n30SlN+HnNx6EbcpoDy9nwdpcGPnEKrJnu6GZoDWBdIjo1UQMVtW2ybtC7LC2oKLcMq8y5g8WnKLiod9g==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    dependencies:
+      lru-cache: 7.18.3
+      minipass: 4.2.5
+    dev: true
+
   /path-type/4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
@@ -3598,6 +3636,14 @@ packages:
     hasBin: true
     dependencies:
       glob: 7.2.3
+    dev: true
+
+  /rimraf/4.4.1:
+    resolution: {integrity: sha512-Gk8NlF062+T9CqNGn6h4tls3k6T1+/nXdOcSZVikNVtlRdYpA7wRJJMoXmuvOnLW844rPjdQ7JgXCYM6PPC/og==}
+    engines: {node: '>=14'}
+    hasBin: true
+    dependencies:
+      glob: 9.3.4
     dev: true
 
   /rollup/3.19.1:

--- a/src/jiti.ts
+++ b/src/jiti.ts
@@ -269,7 +269,7 @@ export default function createJITI(
     } else if (id.startsWith("file:")) {
       id = fileURLToPath(id);
     } else if (isWindows && /^w+:/.test(id)) {
-      id = `file:///${id.replace(/\\/g, "/")}`;
+      id = fileURLToPath(`file:///${id.replace(/\\/g, "/")}`);
     }
 
     // Check for builtin node module like fs

--- a/src/jiti.ts
+++ b/src/jiti.ts
@@ -269,7 +269,7 @@ export default function createJITI(
     } else if (id.startsWith("file:")) {
       id = fileURLToPath(id);
     } else if (isWindows && /^w+:/.test(id)) {
-      id = `file:///${id.replace(/\//g, "\\")}`;
+      id = `file:///${id.replace(/\\/g, "/")}`;
     }
 
     // Check for builtin node module like fs

--- a/src/jiti.ts
+++ b/src/jiti.ts
@@ -268,7 +268,7 @@ export default function createJITI(
       id = id.slice(5);
     } else if (id.startsWith("file:")) {
       id = fileURLToPath(id);
-    } else if (isWindows && /^w+:/.test(id)) {
+    } else if (isWindows && /^\w:/.test(id)) {
       id = fileURLToPath(`file:///${id.replace(/\\/g, "/")}`);
     }
 

--- a/src/jiti.ts
+++ b/src/jiti.ts
@@ -268,6 +268,8 @@ export default function createJITI(
       id = id.slice(5);
     } else if (id.startsWith("file:")) {
       id = fileURLToPath(id);
+    } else if (isWindows && /^w+:/.test(id)) {
+      id = `file:///${id.replace(/\//g, "\\")}`;
     }
 
     // Check for builtin node module like fs

--- a/test/windows.test.ts
+++ b/test/windows.test.ts
@@ -1,0 +1,28 @@
+import { resolve } from "path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import jiti from "../src/jiti";
+
+describe("windows-jiti", () => {
+  beforeEach(() => {
+    vi.mock("os", () => {
+      return {
+        platform: () => "linux",
+      };
+    });
+  });
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("import should fail", () => {
+    const path = resolve(__dirname, "windows.ts");
+    expect(path).toMatch(/^\w:/);
+    let error: Error | undefined;
+    try {
+      jiti(null, { interopDefault: true, esmResolve: true })(path);
+    } catch (error_) {
+      error = error_;
+    }
+    expect(error).toBeDefined();
+  });
+});

--- a/test/windows.ts
+++ b/test/windows.ts
@@ -1,0 +1,1 @@
+export const data = "hey";

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,9 +1,15 @@
 import { defineConfig } from "vitest/config";
 
+const exclude = ["node_modules", "dist", ".idea", ".git", ".cache"];
+if (process.platform !== "win32") {
+  exclude.push("test/windows.test.ts");
+}
+
 export default defineConfig({
   test: {
     coverage: {
       reporter: ["text", "clover", "json"],
     },
+    exclude,
   },
 });


### PR DESCRIPTION
When stubbing (unbuild), Windows paths are absolute but there is no prototol, and so will have unit (`C://...`), adding Windows check and a regexp should fix the problem:

![imagen](https://user-images.githubusercontent.com/6311119/229816548-9fc8d13a-87b1-41d4-b0b0-3790ab22be60.png)
