### PR TITLE
fix: handle nested circular dependencies

### DIFF
--- a/test/__snapshots__/fixtures.test.ts.snap
+++ b/test/__snapshots__/fixtures.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`fixtures > async > stdout 1`] = `"works"`;
 
-exports[`fixtures > circular > stdout 1`] = `"FooBar"`;
+exports[`fixtures > circular > stdout 1`] = `"a b c"`;
 
 exports[`fixtures > env > stdout 1`] = `
 "process.env.TEST true

--- a/test/fixtures/circular/a.js
+++ b/test/fixtures/circular/a.js
@@ -1,5 +1,3 @@
-import { addBase } from "./b";
-
-export const base = "Foo";
-
-export const withBase = (val) => addBase(val);
+export const a = "a";
+export { b } from "./b";
+export { c } from "./c";

--- a/test/fixtures/circular/b.js
+++ b/test/fixtures/circular/b.js
@@ -1,3 +1,3 @@
-import { base } from "./a";
-
-export const addBase = (val) => base + val;
+export { a } from "./a";
+export const b = "b";
+export { c } from "./c";

--- a/test/fixtures/circular/c.js
+++ b/test/fixtures/circular/c.js
@@ -1,0 +1,3 @@
+export { a } from "./a";
+export { b } from "./b";
+export const c = "c";

--- a/test/fixtures/circular/index.js
+++ b/test/fixtures/circular/index.js
@@ -1,3 +1,5 @@
-import { withBase } from "./a";
+import { a } from "./b";
+import { b } from "./c";
+import { c } from "./a";
 
-console.log(withBase("Bar"));
+console.log(a, b, c);


### PR DESCRIPTION
Resolves #141

An extension of #125 to keep a shared cache from (main) parent and children while evaluating. This solves handling nested circular dependencie