### PR TITLE
fix: support `import.meta.env` and `import.meta.env?.prop`

### DIFF
--- a/src/plugins/import-meta-env.ts
+++ b/src/plugins/import-meta-env.ts
@@ -56,21 +56,13 @@ export function importMetaEnvPlugin({ template, types }: any) {
         }
 
         // {}.{}.{}
-        if (
-          !types.isMemberExpression(path.parentPath.node) &&
-          !types.isOptionalMemberExpression(path.parentPath.node)
-        ) {
+        if (!types.isMemberExpression(path.parentPath.node)) {
           return;
         }
 
         // {}.{}.{}.{}
         // @ts-ignore
-        if (
-          // @ts-ignore
-          !types.isMemberExpression(path.parentPath.node.object) &&
-          // @ts-ignore
-          !types.isOptionalMemberExpression(path.parentPath.node.object)
-        ) {
+        if (!types.isMemberExpression(path.parentPath.node.object)) {
           // @ts-ignore
           if (!types.isMetaProperty(path.parentPath.node.object)) {
             return;

--- a/src/plugins/import-meta-env.ts
+++ b/src/plugins/import-meta-env.ts
@@ -1,31 +1,5 @@
 /**
- * Based on https://github.com/iendeavor/import-meta-env/tree/main/packages/babel 0.4.2 (MIT)
-
-Modified to use runtime only without dotenv dependency
-
----
-
-MIT License
-
-Copyright (c) 2021 Ernest
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+ * Forked from https://github.com/iendeavor/import-meta-env/tree/main/packages/babel 0.4.2 (MIT License - Copyright (c) 2021 Ernest)
  */
 
 import type { PluginObj } from "@babel/core";

--- a/test/__snapshots__/fixtures.test.ts.snap
+++ b/test/__snapshots__/fixtures.test.ts.snap
@@ -5,8 +5,12 @@ exports[`fixtures > async > stdout 1`] = `"works"`;
 exports[`fixtures > circular > stdout 1`] = `"a b c"`;
 
 exports[`fixtures > env > stdout 1`] = `
-"process.env.TEST true
-import.meta.env.TEST true"
+"process.env true
+process.env.TEST true
+process.env?.TEST true
+import.meta true
+import.meta.env.TEST true
+import.meta.env?.TEST true"
 `;
 
 exports[`fixtures > error-parse > stderr 1`] = `

--- a/test/fixtures/env/index.ts
+++ b/test/fixtures/env/index.ts
@@ -1,3 +1,10 @@
+console.log("process.env", Object.keys(process.env).includes("TEST"));
 console.log("process.env.TEST", process.env.TEST);
+console.log("process.env?.TEST", process.env?.TEST);
+
+// @ts-ignore
+console.log("import.meta", Object.keys(import.meta.env).includes("TEST"));
 // @ts-ignore
 console.log("import.meta.env.TEST", import.meta.env.TEST);
+// @ts-ignore
+console.log("import.meta.env?.TEST", import.meta.env?.TEST);


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Currently, we support `import.meta.env.foobar` by replacing AST to `process.env.foobar` but using `import.meta.env` itself was not possible and could possibly make issues like cannot use import outside of a module.

This PR also adds support for `import.meta.env?` with optional chaining, increases type safety and simplifies code.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
