### PR TITLE
feat: add `jiti.import` function for async import

### DIFF
--- a/src/jiti.ts
+++ b/src/jiti.ts
@@ -69,6 +69,7 @@ export interface JITI extends Require {
   transform: (opts: TransformOptions) => string;
   register: () => () => void;
   evalModule: (source: string, options?: EvalModuleOptions) => unknown;
+  /** @experimental Behavior of `jiti.import` might change in the future. */
   import: (id: string) => Promise<unknown>;
 }
 

--- a/src/jiti.ts
+++ b/src/jiti.ts
@@ -69,6 +69,7 @@ export interface JITI extends Require {
   transform: (opts: TransformOptions) => string;
   register: () => () => void;
   evalModule: (source: string, options?: EvalModuleOptions) => unknown;
+  import: (id: string) => Promise<unknown>;
 }
 
 const JS_EXT_RE = /\.(c|m)?j(sx?)$/;
@@ -487,6 +488,7 @@ export default function createJITI(
   jiti.transform = transform;
   jiti.register = register;
   jiti.evalModule = evalModule;
+  jiti.import = async (id: string) => await jiti(id);
 
   return jiti;
 }


### PR DESCRIPTION
related to #32

It should be the very first step to have an async import function for ESM, which we could improve the implemtation later. Unblocks #158 