### PR TITLE
feat: basic top-level await support

### DIFF
--- a/bin/jiti.js
+++ b/bin/jiti.js
@@ -5,7 +5,6 @@ const { resolve } = require("node:path");
 const script = process.argv.splice(2, 1)[0];
 
 if (!script) {
-   
   console.error("Usage: jiti <path> [...arguments]");
   process.exit(1);
 }
@@ -13,4 +12,6 @@ if (!script) {
 const pwd = process.cwd();
 const jiti = require("..")(pwd);
 const resolved = (process.argv[1] = jiti.resolve(resolve(pwd, script)));
-jiti(resolved);
+
+// eslint-disable-next-line unicorn/prefer-top-level-await
+jiti.import(resolved).catch(console.error);

--- a/bin/jiti.js
+++ b/bin/jiti.js
@@ -13,5 +13,5 @@ const pwd = process.cwd();
 const jiti = require("..")(pwd);
 const resolved = (process.argv[1] = jiti.resolve(resolve(pwd, script)));
 
-// eslint-disable-next-line unicorn/prefer-top-level-await
+ 
 jiti.import(resolved).catch(console.error);

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,6 +5,7 @@ export default unjs({
     "test/fixtures/error-*"
   ],
   rules: {
-    "unicorn/no-null": 0
+    "unicorn/no-null": 0,
+    "unicorn/prefer-top-level-await": 0
   },
 });

--- a/src/jiti.ts
+++ b/src/jiti.ts
@@ -400,7 +400,6 @@ export default function createJITI(
     // Compile wrapped script
     let compiled;
     try {
-      // @ts-ignore
       compiled = vm.runInThisContext(
         wrapModule(source, { async: evalOptions.async }),
         {

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,4 +35,7 @@ export type JITIOptions = {
 export interface JITIImportOptions {
   /** @internal */
   _import?: () => Promise<any>;
+
+  /** @internal */
+  _async?: boolean;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -72,3 +72,7 @@ export function readNearestPackageJSON(path: string): PackageJson | undefined {
     }
   }
 }
+
+export function wrapModule(source: string, opts?: { async?: boolean }) {
+  return `(${opts?.async ? "async " : ""}function (exports, require, module, __filename, __dirname) { ${source}\n});`;
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -74,5 +74,8 @@ export function readNearestPackageJSON(path: string): PackageJson | undefined {
 }
 
 export function wrapModule(source: string, opts?: { async?: boolean }) {
+  if (opts?.async) {
+    source = source.replace(/(\s*=\s*)require\(/g, "$1await require(");
+  }
   return `(${opts?.async ? "async " : ""}function (exports, require, module, __filename, __dirname) { ${source}\n});`;
 }

--- a/test/__snapshots__/fixtures.test.ts.snap
+++ b/test/__snapshots__/fixtures.test.ts.snap
@@ -14,28 +14,28 @@ import.meta.env?.TEST true"
 `;
 
 exports[`fixtures > error-parse > stderr 1`] = `
-"<root>/lib/index.js:2
-  throw err; /* ↓ Check stack trace ↓ */
-  ^
-
-Error: ParseError: \`import\` can only be used in \`import 
+"Error: ParseError: \`import\` can only be used in \`import 
  <cwd>/index.ts
+    at <root>/dist/jiti.js
+    at Generator.next (<anonymous>)
+    at <root>/dist/jiti.js
+    at new Promise (<anonymous>)
+    at __awaiter (<root>/dist/jiti)
+    at jiti.import (<root>/dist/jiti)
     at Object.<anonymous> (<root>/bin/jiti)
     at Module._compile (internal/modules/cjs/loader)
     at Module._extensions..js (internal/modules/cjs/loader)
     at Module.load (internal/modules/cjs/loader)
     at Module._load (internal/modules/cjs/loader)
     at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main)
-    at internal/main/run_main_module
-
-Node.js v<version>"
+    at internal/main/run_main_module"
 `;
 
 exports[`fixtures > error-parse > stdout 1`] = `""`;
 
 exports[`fixtures > error-runtime > stderr 1`] = `
-"<root>/lib/index.js:2
-  throw err; /* ↓ Check stack trace ↓ */
+"events:276
+  validateFunction(listener, 'listener');
   ^
 
 TypeError: The "listener" argument must be of type function. Received undefined
@@ -45,6 +45,12 @@ TypeError: The "listener" argument must be of type function. Received undefined
     at <cwd>/index.ts
     at evalModule (<root>/dist/jiti)
     at jiti (<root>/dist/jiti)
+    at <root>/dist/jiti.js
+    at Generator.next (<anonymous>)
+    at <root>/dist/jiti.js
+    at new Promise (<anonymous>)
+    at __awaiter (<root>/dist/jiti)
+    at jiti.import (<root>/dist/jiti)
     at Object.<anonymous> (<root>/bin/jiti)
     at Module._compile (internal/modules/cjs/loader)
     at Module._extensions..js (internal/modules/cjs/loader)
@@ -72,6 +78,12 @@ exports[`fixtures > esm > stdout 1`] = `
     'at <cwd>/index.js',
     'at evalModule (<root>/dist/jiti)',
     'at jiti (<root>/dist/jiti)',
+    'at <root>/dist/jiti.js',
+    'at Generator.next (<anonymous>)',
+    'at <root>/dist/jiti.js',
+    'at new Promise (<anonymous>)',
+    'at __awaiter (<root>/dist/jiti)',
+    'at jiti.import (<root>/dist/jiti)',
     'at Object.<anonymous> (<root>/bin/jiti)',
     'at Module._compile (internal/modules/cjs/loader)',
     'at Module._extensions..js (internal/modules/cjs/loader)',
@@ -119,6 +131,8 @@ Nullish coalescing: 0
 Logical or assignment: 50 title is empty.
 Logical nullish assignment: 50 20"
 `;
+
+exports[`fixtures > top-level-await > stdout 1`] = `"async value works"`;
 
 exports[`fixtures > typescript > stdout 1`] = `
 "Decorator metadata keys: design:type

--- a/test/__snapshots__/fixtures.test.ts.snap
+++ b/test/__snapshots__/fixtures.test.ts.snap
@@ -132,7 +132,7 @@ Logical or assignment: 50 title is empty.
 Logical nullish assignment: 50 20"
 `;
 
-exports[`fixtures > top-level-await > stdout 1`] = `"async value works"`;
+exports[`fixtures > top-level-await > stdout 1`] = `"async value works from sub module"`;
 
 exports[`fixtures > typescript > stdout 1`] = `
 "Decorator metadata keys: design:type

--- a/test/bun.test.ts
+++ b/test/bun.test.ts
@@ -21,9 +21,16 @@ for (const fixture of fixtures) {
   if (fixture.startsWith("error-")) {
     continue;
   }
-  test("fixtures/" + fixture, () => {
-    _jiti("./" + fixture);
-  });
+  if (!fixture.includes("await")) {
+    test("fixtures/" + fixture + " (CJS)", () => {
+      _jiti("./" + fixture);
+    });
+  }
+  if (!fixture.includes("typescript")) {
+    test("fixtures/" + fixture + " (ESM)", async () => {
+      await _jiti.import("./" + fixture);
+    });
+  }
 }
 
 test("hmr", async () => {

--- a/test/fixtures.test.ts
+++ b/test/fixtures.test.ts
@@ -18,21 +18,30 @@ describe("fixtures", async () => {
 
       // Clean up absolute paths and sourcemap locations for stable snapshots
       function cleanUpSnap(str: string) {
-        return (str + "\n")
-          .replace(/\n\t/g, "\n")
-          .replace(/\\+/g, "/")
-          .split(cwd.replace(/\\/g, "/"))
-          .join("<cwd>") // workaround for replaceAll in Node 14
-          .split(root.replace(/\\/g, "/"))
-          .join("<root>") // workaround for replaceAll in Node 14
-          .replace(/:\d+:\d+([\s')])/g, "$1") // remove line numbers in stacktrace
-          .replace(/node:(internal|events)/g, "$1") // in Node 16 internal will be presented as node:internal
-          .replace(/\.js\)/g, ")")
-          .replace(/file:\/{3}/g, "file://")
-          .replace(/Node.js v[\d.]+/, "Node.js v<version>")
-          .replace(/ParseError: \w:\/:\s+/, "ParseError: ") // Unknown chars in Windows
-          .replace("TypeError [ERR_INVALID_ARG_TYPE]:", "TypeError:")
-          .trim();
+        return (
+          (str + "\n")
+            .replace(/\n\t/g, "\n")
+            .replace(/\\+/g, "/")
+            .split(cwd.replace(/\\/g, "/"))
+            .join("<cwd>") // workaround for replaceAll in Node 14
+            .split(root.replace(/\\/g, "/"))
+            .join("<root>") // workaround for replaceAll in Node 14
+            .replace(/:\d+:\d+([\s')])/g, "$1") // remove line numbers in stacktrace
+            .replace(/node:(internal|events)/g, "$1") // in Node 16 internal will be presented as node:internal
+            .replace(/\.js\)/g, ")")
+            .replace(/file:\/{3}/g, "file://")
+            .replace(/Node.js v[\d.]+/, "Node.js v<version>")
+            .replace(/ParseError: \w:\/:\s+/, "ParseError: ") // Unknown chars in Windows
+            .replace("TypeError [ERR_INVALID_ARG_TYPE]:", "TypeError:")
+            // Node 18
+            .replace(
+              "  ErrorCaptureStackTrace(err);",
+              "validateFunction(listener, 'listener');",
+            )
+            .replace("internal/errors:496", "events:276")
+            .replace("    ^", "  ^")
+            .trim()
+        );
       }
 
       const { stdout, stderr } = await execa("node", [jitiPath, fixtureEntry], {

--- a/test/fixtures/async/index.js
+++ b/test/fixtures/async/index.js
@@ -2,5 +2,4 @@ async function main() {
   await import("./async.mjs").then((m) => console.log(m.async));
 }
 
-// eslint-disable-next-line unicorn/prefer-top-level-await
 main().catch(console.error);

--- a/test/fixtures/json/index.ts
+++ b/test/fixtures/json/index.ts
@@ -10,5 +10,5 @@ const debug = (label: string, value) =>
 debug("Imported", imported);
 debug("Imported with assertion", importedWithAssertion);
 debug("Required", required);
-// eslint-disable-next-line unicorn/prefer-top-level-await
+
 import("./file.json").then((r) => debug("Dynamic Imported", r));

--- a/test/fixtures/native/index.js
+++ b/test/fixtures/native/index.js
@@ -1,2 +1,1 @@
-// eslint-disable-next-line unicorn/prefer-top-level-await
 import("./test.mjs").then(console.log);

--- a/test/fixtures/top-level-await/async.mjs
+++ b/test/fixtures/top-level-await/async.mjs
@@ -1,0 +1,1 @@
+export const asyncValue = await Promise.resolve("async value works");

--- a/test/fixtures/top-level-await/index.ts
+++ b/test/fixtures/top-level-await/index.ts
@@ -1,1 +1,4 @@
-import("./async.mjs").then((m) => console.log(m.asyncValue));
+await import("./sub").then((m) => console.log(m.test));
+
+// Mark file as module for typescript
+export default {};

--- a/test/fixtures/top-level-await/index.ts
+++ b/test/fixtures/top-level-await/index.ts
@@ -1,0 +1,1 @@
+import("./async.mjs").then((m) => console.log(m.asyncValue));

--- a/test/fixtures/top-level-await/sub.ts
+++ b/test/fixtures/top-level-await/sub.ts
@@ -1,0 +1,3 @@
+import { asyncValue } from "./async.mjs";
+
+export const test = asyncValue + " from sub module";


### PR DESCRIPTION
This PR supports basic [top level await](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await#top_level_await) support via `jiti.import()` and `jiti <path>` CLI.

Implementation is fairly basic and adds support by wrapping the module into an `async function` instead of `function` that Node.js does.

In order to allow chained usage, since jiti transforms all imports to require internally, we replace ` = require(` patterns to ` = await require` in async contexts to make sure they are resolved. (this is more of a workaround but better than not having it!)
