### PR TITLE
refactor: split logic

### DIFF
--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,0 +1,81 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join, basename } from "pathe";
+import { debug, isWritable, md5 } from "./utils";
+import { tmpdir } from "node:os";
+import type { Context } from "./types";
+
+export function getCache(
+  ctx: Context,
+  filename: string | undefined,
+  source: string,
+  get: () => string,
+): string {
+  if (!ctx.opts.cache || !filename) {
+    return get();
+  }
+
+  // Calculate source hash
+  const sourceHash = ` /* v${ctx.opts.cacheVersion}-${md5(source, 16)} */`;
+
+  // Check cache file
+  const filebase = basename(dirname(filename)) + "-" + basename(filename);
+  const cacheFile = join(
+    ctx.opts.cache as string,
+    filebase + "." + md5(filename) + ".js",
+  );
+
+  if (existsSync(cacheFile)) {
+    const cacheSource = readFileSync(cacheFile, "utf8");
+    if (cacheSource.endsWith(sourceHash)) {
+      debug(ctx, "[cache hit]", filename, "~>", cacheFile);
+      return cacheSource;
+    }
+  }
+
+  debug(ctx, "[cache miss]", filename);
+  const result = get();
+
+  if (!result.includes("__JITI_ERROR__")) {
+    writeFileSync(cacheFile, result + sourceHash, "utf8");
+  }
+
+  return result;
+}
+
+export function prepareCacheDir(ctx: Context) {
+  if (ctx.opts.cache === true) {
+    ctx.opts.cache = getCacheDir();
+  }
+  if (ctx.opts.cache) {
+    try {
+      mkdirSync(ctx.opts.cache as string, { recursive: true });
+      if (!isWritable(ctx.opts.cache)) {
+        throw new Error("directory is not writable!");
+      }
+    } catch (error: any) {
+      debug(ctx, "Error creating cache directory at ", ctx.opts.cache, error);
+      ctx.opts.cache = false;
+    }
+  }
+}
+
+export function getCacheDir() {
+  let _tmpDir = tmpdir();
+
+  // Workaround for pnpm setting an incorrect `TMPDIR`.
+  // Set `JITI_RESPECT_TMPDIR_ENV` to a truthy value to disable this workaround.
+  // https://github.com/pnpm/pnpm/issues/6140
+  // https://github.com/unjs/jiti/issues/120
+  if (
+    process.env.TMPDIR &&
+    _tmpDir === process.cwd() &&
+    !process.env.JITI_RESPECT_TMPDIR_ENV
+  ) {
+    const _env = process.env.TMPDIR;
+    delete process.env.TMPDIR;
+    _tmpDir = tmpdir();
+    process.env.TMPDIR = _env;
+  }
+
+  return join(_tmpDir, "node-jiti");
+}

--- a/src/esm.ts
+++ b/src/esm.ts
@@ -1,0 +1,10 @@
+import { dirname } from "pathe";
+import { jitiResolve } from "./resolve";
+import { Context } from "./types";
+
+export function nativeImport(ctx: Context, id: string) {
+  const resolvedId = jitiResolve(ctx, id, { paths: [dirname(ctx.filename)] });
+  // TODO: use subpath to avoid webpack transform instead
+  const _dynamicImport = new Function("url", "return import(url)") as any;
+  return _dynamicImport(resolvedId);
+}

--- a/src/eval.ts
+++ b/src/eval.ts
@@ -1,0 +1,150 @@
+import { Module } from "node:module";
+import { performance } from "node:perf_hooks";
+import vm from "node:vm";
+import { dirname, basename, extname } from "pathe";
+import { hasESMSyntax } from "mlly";
+import {
+  debug,
+  detectLegacySyntax,
+  jitiInteropDefault,
+  readNearestPackageJSON,
+  wrapModule,
+} from "./utils";
+import type { ModuleCache, Context, EvalModuleOptions } from "./types";
+import { jitiResolve } from "./resolve";
+import { jitiRequire } from "./require";
+import createJITI from "./jiti";
+import { transform } from "./transform";
+
+export function evalModule(
+  ctx: Context,
+  source: string,
+  evalOptions: EvalModuleOptions = {},
+) {
+  // Resolve options
+  const id =
+    evalOptions.id ||
+    (evalOptions.filename
+      ? basename(evalOptions.filename)
+      : `_jitiEval.${evalOptions.ext || ".js"}`);
+  const filename = evalOptions.filename || jitiResolve(ctx, id);
+  const ext = evalOptions.ext || extname(filename);
+  const cache = (evalOptions.cache || ctx.parentCache || {}) as ModuleCache;
+
+  // Transpile
+  const isTypescript = ext === ".ts" || ext === ".mts" || ext === ".cts";
+  const isNativeModule =
+    ext === ".mjs" ||
+    (ext === ".js" && readNearestPackageJSON(filename)?.type === "module");
+  const isCommonJS = ext === ".cjs";
+  const needsTranspile =
+    !isCommonJS &&
+    (isTypescript ||
+      isNativeModule ||
+      ctx.isTransformRe.test(filename) ||
+      hasESMSyntax(source) ||
+      (ctx.opts.legacy && detectLegacySyntax(source)));
+
+  const start = performance.now();
+  if (needsTranspile) {
+    source = transform(ctx, { filename, source, ts: isTypescript });
+    const time = Math.round((performance.now() - start) * 1000) / 1000;
+    debug(
+      ctx,
+      `[transpile]${isNativeModule ? " [esm]" : ""}`,
+      filename,
+      `(${time}ms)`,
+    );
+  } else {
+    try {
+      debug(ctx, "[native]", filename);
+      return jitiInteropDefault(ctx, ctx.nativeRequire(id));
+    } catch (error: any) {
+      debug(ctx, "Native require error:", error);
+      debug(ctx, "[fallback]", filename);
+      source = transform(ctx, { filename, source, ts: isTypescript });
+    }
+  }
+
+  // Compile module
+  const mod = new Module(filename);
+  mod.filename = filename;
+  if (ctx.parentModule) {
+    mod.parent = ctx.parentModule;
+    if (
+      Array.isArray(ctx.parentModule.children) &&
+      !ctx.parentModule.children.includes(mod)
+    ) {
+      ctx.parentModule.children.push(mod);
+    }
+  }
+
+  mod.require = createJITI(filename, ctx.opts, mod, cache, {
+    _async: evalOptions.async,
+  });
+
+  // @ts-ignore
+  mod.path = dirname(filename);
+
+  // @ts-ignore
+  mod.paths = Module._nodeModulePaths(mod.path);
+
+  // Set CJS cache before eval
+  cache[filename] = mod;
+  if (ctx.opts.requireCache) {
+    ctx.nativeRequire.cache[filename] = mod;
+  }
+
+  // Compile wrapped script
+  let compiled;
+  try {
+    compiled = vm.runInThisContext(
+      wrapModule(source, { async: evalOptions.async }),
+      {
+        filename,
+        lineOffset: 0,
+        displayErrors: false,
+      },
+    );
+  } catch (error: any) {
+    if (ctx.opts.requireCache) {
+      delete ctx.nativeRequire.cache[filename];
+    }
+    ctx.opts.onError!(error);
+  }
+
+  // Evaluate module
+  try {
+    compiled(
+      mod.exports,
+      mod.require,
+      mod,
+      mod.filename,
+      dirname(mod.filename),
+    );
+  } catch (error: any) {
+    if (ctx.opts.requireCache) {
+      delete ctx.nativeRequire.cache[filename];
+    }
+    ctx.opts.onError!(error);
+  }
+
+  // Check for parse errors
+  if (mod.exports && mod.exports.__JITI_ERROR__) {
+    const { filename, line, column, code, message } =
+      mod.exports.__JITI_ERROR__;
+    const loc = `${filename}:${line}:${column}`;
+    const err = new Error(`${code}: ${message} \n ${loc}`);
+    Error.captureStackTrace(err, jitiRequire);
+    ctx.opts.onError!(err);
+  }
+
+  // Set as loaded
+  mod.loaded = true;
+
+  // interopDefault
+  const _exports = jitiInteropDefault(ctx, mod.exports);
+
+  // Return exports
+  return _exports;
+}

--- a/src/jiti.ts
+++ b/src/jiti.ts
@@ -1,4 +1,3 @@
-import { mkdirSync } from "node:fs";
 import { platform } from "node:os";
 import { pathToFileURL } from "node:url";
 import { join } from "pathe";

--- a/src/jiti.ts
+++ b/src/jiti.ts
@@ -1,490 +1,143 @@
-import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
-import { Module, builtinModules } from "node:module";
-import { performance } from "node:perf_hooks";
+import { mkdirSync } from "node:fs";
 import { platform } from "node:os";
-import vm from "node:vm";
-import { fileURLToPath, pathToFileURL } from "node:url";
-import { dirname, join, basename, extname } from "pathe";
+import { pathToFileURL } from "node:url";
+import { join } from "pathe";
 import escapeStringRegexp from "escape-string-regexp";
 import createRequire from "create-require";
-import { normalizeAliases, resolveAlias } from "pathe/utils";
+import { normalizeAliases } from "pathe/utils";
 import { addHook } from "pirates";
-import { hasESMSyntax, interopDefault, resolvePathSync } from "mlly";
-import {
-  getCacheDir,
-  isDir,
-  isWritable,
-  md5,
-  detectLegacySyntax,
-  readNearestPackageJSON,
-  wrapModule,
-} from "./utils";
+import { isDir } from "./utils";
 import { resolveJitiOptions } from "./options";
-import type { TransformOptions, JITIOptions, JITIImportOptions } from "./types";
+import type {
+  JITI,
+  TransformOptions,
+  JITIOptions,
+  JITIImportOptions,
+  ModuleCache,
+  Context,
+  EvalModuleOptions,
+} from "./types";
+import { jitiResolve } from "./resolve";
+import { evalModule } from "./eval";
+import { transform } from "./transform";
+import { jitiRequire } from "./require";
+import { prepareCacheDir } from "./cache";
 
-export type { JITIOptions, TransformOptions } from "./types";
+export type { JITI, JITIOptions, TransformOptions } from "./types";
 
 const isWindows = platform() === "win32";
 
-type Require = typeof require;
-type Module = typeof module;
-
-type ModuleCache = Record<string, Module>;
-
-export type EvalModuleOptions = Partial<{
-  id: string;
-  filename: string;
-  ext: string;
-  cache: ModuleCache;
-  async: boolean;
-}>;
-
-export interface JITI extends Require {
-  transform: (opts: TransformOptions) => string;
-  register: () => () => void;
-  evalModule: (source: string, options?: EvalModuleOptions) => unknown;
-  /** @experimental Behavior of `jiti.import` might change in the future. */
-  import: (id: string, importOptions: JITIImportOptions) => Promise<unknown>;
-}
-
-const JS_EXT_RE = /\.(c|m)?j(sx?)$/;
-const TS_EXT_RE = /\.(c|m)?t(sx?)$/;
-
 export default function createJITI(
-  _filename: string,
+  filename: string,
   userOptions: JITIOptions = {},
-  parentModule?: Module,
+  parentModule?: NodeModule,
   parentCache?: ModuleCache,
   parentImportOptions?: JITIImportOptions,
 ): JITI {
+  // Resolve options
   const opts = resolveJitiOptions(userOptions);
 
   // Normalize aliases (and disable if non given)
   const alias =
     opts.alias && Object.keys(opts.alias).length > 0
       ? normalizeAliases(opts.alias || {})
-      : null;
+      : undefined;
 
   // List of modules to force transform or native
   const nativeModules = ["typescript", "jiti", ...(opts.nativeModules || [])];
-  const transformModules = [...(opts.transformModules || [])];
   const isNativeRe = new RegExp(
     `node_modules/(${nativeModules
       .map((m) => escapeStringRegexp(m))
       .join("|")})/`,
   );
+
+  const transformModules = [...(opts.transformModules || [])];
   const isTransformRe = new RegExp(
     `node_modules/(${transformModules
       .map((m) => escapeStringRegexp(m))
       .join("|")})/`,
   );
 
-  function debug(...args: string[]) {
-    if (opts.debug) {
-      console.log("[jiti]", ...args);
-    }
-  }
-
   // If filename is dir, createRequire goes with parent directory, so we need fakepath
-  if (!_filename) {
-    _filename = process.cwd();
+  if (!filename) {
+    filename = process.cwd();
   }
-  if (isDir(_filename)) {
-    _filename = join(_filename, "index.js");
+  if (isDir(filename)) {
+    filename = join(filename, "index.js");
   }
 
-  if (opts.cache === true) {
-    opts.cache = getCacheDir();
-  }
-  if (opts.cache) {
-    try {
-      mkdirSync(opts.cache as string, { recursive: true });
-      if (!isWritable(opts.cache)) {
-        throw new Error("directory is not writable");
-      }
-    } catch (error: any) {
-      debug("Error creating cache directory at ", opts.cache, error);
-      opts.cache = false;
-    }
-  }
+  const url = pathToFileURL(filename);
+
+  const additionalExts = [...(opts.extensions as string[])].filter(
+    (ext) => ext !== ".js",
+  );
 
   const nativeRequire = createRequire(
     isWindows
-      ? _filename.replace(/\//g, "\\") // Import maps does not work with normalized paths!
-      : _filename,
+      ? filename.replace(/\//g, "\\") // Import maps does not work with normalized paths!
+      : filename,
   );
 
-  let _dynamicImport: (id: string) => Promise<any>;
-  const nativeImport = (id: string) => {
-    const resolvedId = _resolve(id, { paths: [dirname(_filename)] });
-    // TODO: use subpath to avoid webpack transform instead
-    _dynamicImport ??= new Function("url", "return import(url)") as any;
-    return _dynamicImport(resolvedId);
+  // Create shared context
+  const ctx: Context = {
+    filename,
+    url,
+    userOptions,
+    parentModule,
+    parentCache,
+    parentImportOptions,
+    opts,
+    alias,
+    nativeModules,
+    transformModules,
+    isNativeRe,
+    isTransformRe,
+    additionalExts,
+    nativeRequire,
   };
 
-  const tryResolve = (id: string, options?: { paths?: string[] }) => {
-    try {
-      return nativeRequire.resolve(id, options);
-    } catch {
-      // Ignore errors
-    }
-  };
+  // Prepare cache dir
+  prepareCacheDir(ctx);
 
-  const _url = pathToFileURL(_filename);
-  const _additionalExts = [...(opts.extensions as string[])].filter(
-    (ext) => ext !== ".js",
-  );
-  const _resolve = (id: string, options?: { paths?: string[] }) => {
-    let resolved, err;
-
-    // Resolve alias
-    if (alias) {
-      id = resolveAlias(id, alias);
-    }
-
-    // Try ESM resolve
-    if (opts.esmResolve) {
-      const conditionSets = [
-        ["node", "require"],
-        ["node", "import"],
-      ];
-      for (const conditions of conditionSets) {
-        try {
-          resolved = resolvePathSync(id, {
-            url: _url,
-            conditions,
-            extensions: opts.extensions,
-          });
-        } catch (error) {
-          err = error;
-        }
-        if (resolved) {
-          return resolved;
-        }
-      }
-    }
-
-    // Try native require resolve
-    try {
-      return nativeRequire.resolve(id, options);
-    } catch (error) {
-      err = error;
-    }
-    for (const ext of _additionalExts) {
-      resolved =
-        tryResolve(id + ext, options) ||
-        tryResolve(id + "/index" + ext, options);
-      if (resolved) {
-        return resolved;
-      }
-      // Try resolving .ts files with .js extension
-      if (TS_EXT_RE.test(parentModule?.filename || "")) {
-        resolved = tryResolve(id.replace(JS_EXT_RE, ".$1t$2"), options);
-        if (resolved) {
-          return resolved;
-        }
-      }
-    }
-    throw err;
-  };
-  _resolve.paths = nativeRequire.resolve.paths;
-
-  function getCache(
-    filename: string | undefined,
-    source: string,
-    get: () => string,
-  ): string {
-    if (!opts.cache || !filename) {
-      return get();
-    }
-
-    // Calculate source hash
-    const sourceHash = ` /* v${opts.cacheVersion}-${md5(source, 16)} */`;
-
-    // Check cache file
-    const filebase = basename(dirname(filename)) + "-" + basename(filename);
-    const cacheFile = join(
-      opts.cache as string,
-      filebase + "." + md5(filename) + ".js",
-    );
-
-    if (existsSync(cacheFile)) {
-      const cacheSource = readFileSync(cacheFile, "utf8");
-      if (cacheSource.endsWith(sourceHash)) {
-        debug("[cache hit]", filename, "~>", cacheFile);
-        return cacheSource;
-      }
-    }
-
-    debug("[cache miss]", filename);
-    const result = get();
-
-    if (!result.includes("__JITI_ERROR__")) {
-      writeFileSync(cacheFile, result + sourceHash, "utf8");
-    }
-
-    return result;
-  }
-
-  function transform(topts: any): string {
-    let code = getCache(topts.filename, topts.source, () => {
-      const res = opts.transform!({
-        legacy: opts.legacy,
-        ...opts.transformOptions,
-        babel: {
-          ...(opts.sourceMaps
-            ? {
-                sourceFileName: topts.filename,
-                sourceMaps: "inline",
-              }
-            : {}),
-          ...opts.transformOptions?.babel,
+  // Create jiti instance
+  const jiti: JITI = Object.assign(
+    function jiti(id: string, importOptions?: JITIImportOptions) {
+      return jitiRequire(ctx, id, importOptions);
+    },
+    {
+      cache: opts.requireCache ? nativeRequire.cache : {},
+      extensions: nativeRequire.extensions,
+      main: nativeRequire.main,
+      resolve: Object.assign(
+        function resolve(path: string) {
+          return jitiResolve(ctx, path);
         },
-        ...topts,
-      });
-      if (res.error && opts.debug) {
-        debug(res.error);
-      }
-      return res.code;
-    });
-    if (code.startsWith("#!")) {
-      code = "// " + code;
-    }
-    return code;
-  }
-
-  function _interopDefault(mod: any) {
-    return opts.interopDefault ? interopDefault(mod) : mod;
-  }
-
-  function jiti(id: string, importOptions?: JITIImportOptions) {
-    const cache = parentCache || {};
-
-    // Check for node: and file: protocol
-    if (id.startsWith("node:")) {
-      id = id.slice(5);
-    } else if (id.startsWith("file:")) {
-      id = fileURLToPath(id);
-    }
-
-    // Check for builtin node module like fs
-    if (builtinModules.includes(id) || id === ".pnp.js" /* #24 */) {
-      return nativeRequire(id);
-    }
-
-    // Experimental Bun support
-    if (opts.experimentalBun && !opts.transformOptions) {
-      try {
-        debug(`[bun] [native] ${id}`);
-        if (importOptions?._async) {
-          return nativeImport(id).then((m: any) => {
-            if (opts.requireCache === false) {
-              delete nativeRequire.cache[id];
-            }
-            return _interopDefault(m);
-          });
-        } else {
-          const _mod = nativeRequire(id);
-          if (opts.requireCache === false) {
-            delete nativeRequire.cache[id];
-          }
-          return _interopDefault(_mod);
-        }
-      } catch (error: any) {
-        debug(`[bun] Using fallback for ${id} because of an error:`, error);
-      }
-    }
-
-    // Resolve path
-    const filename = _resolve(id);
-    const ext = extname(filename);
-
-    // Check for .json modules
-    if (ext === ".json") {
-      debug("[json]", filename);
-      const jsonModule = nativeRequire(id);
-      Object.defineProperty(jsonModule, "default", { value: jsonModule });
-      return jsonModule;
-    }
-
-    // Unknown format
-    if (ext && !opts.extensions!.includes(ext)) {
-      debug("[unknown]", filename);
-      return nativeRequire(id);
-    }
-
-    // Force native modules
-    if (isNativeRe.test(filename)) {
-      debug("[native]", filename);
-      return nativeRequire(id);
-    }
-
-    // Check for CJS cache
-    if (cache[filename]) {
-      return _interopDefault(cache[filename]?.exports);
-    }
-    if (opts.requireCache && nativeRequire.cache[filename]) {
-      return _interopDefault(nativeRequire.cache[filename]?.exports);
-    }
-
-    // Read source
-    const source = readFileSync(filename, "utf8");
-
-    // Evaluate module
-    return evalModule(source, {
-      id,
-      filename,
-      ext,
-      cache,
-      async: importOptions?._async ?? parentImportOptions?._async,
-    });
-  }
-
-  function evalModule(source: string, evalOptions: EvalModuleOptions = {}) {
-    // Resolve options
-    const id =
-      evalOptions.id ||
-      (evalOptions.filename
-        ? basename(evalOptions.filename)
-        : `_jitiEval.${evalOptions.ext || ".js"}`);
-    const filename = evalOptions.filename || _resolve(id);
-    const ext = evalOptions.ext || extname(filename);
-    const cache = (evalOptions.cache || parentCache || {}) as ModuleCache;
-
-    // Transpile
-    const isTypescript = ext === ".ts" || ext === ".mts" || ext === ".cts";
-    const isNativeModule =
-      ext === ".mjs" ||
-      (ext === ".js" && readNearestPackageJSON(filename)?.type === "module");
-    const isCommonJS = ext === ".cjs";
-    const needsTranspile =
-      !isCommonJS &&
-      (isTypescript ||
-        isNativeModule ||
-        isTransformRe.test(filename) ||
-        hasESMSyntax(source) ||
-        (opts.legacy && detectLegacySyntax(source)));
-
-    const start = performance.now();
-    if (needsTranspile) {
-      source = transform({ filename, source, ts: isTypescript });
-      const time = Math.round((performance.now() - start) * 1000) / 1000;
-      debug(
-        `[transpile]${isNativeModule ? " [esm]" : ""}`,
-        filename,
-        `(${time}ms)`,
-      );
-    } else {
-      try {
-        debug("[native]", filename);
-        return _interopDefault(nativeRequire(id));
-      } catch (error: any) {
-        debug("Native require error:", error);
-        debug("[fallback]", filename);
-        source = transform({ filename, source, ts: isTypescript });
-      }
-    }
-
-    // Compile module
-    const mod = new Module(filename);
-    mod.filename = filename;
-    if (parentModule) {
-      mod.parent = parentModule;
-      if (
-        Array.isArray(parentModule.children) &&
-        !parentModule.children.includes(mod)
-      ) {
-        parentModule.children.push(mod);
-      }
-    }
-
-    mod.require = createJITI(filename, opts, mod, cache, {
-      _async: evalOptions.async,
-    });
-
-    // @ts-ignore
-    mod.path = dirname(filename);
-
-    // @ts-ignore
-    mod.paths = Module._nodeModulePaths(mod.path);
-
-    // Set CJS cache before eval
-    cache[filename] = mod;
-    if (opts.requireCache) {
-      nativeRequire.cache[filename] = mod;
-    }
-
-    // Compile wrapped script
-    let compiled;
-    try {
-      compiled = vm.runInThisContext(
-        wrapModule(source, { async: evalOptions.async }),
         {
-          filename,
-          lineOffset: 0,
-          displayErrors: false,
+          paths: nativeRequire.resolve.paths,
         },
-      );
-    } catch (error: any) {
-      if (opts.requireCache) {
-        delete nativeRequire.cache[filename];
-      }
-      opts.onError!(error);
-    }
-
-    // Evaluate module
-    try {
-      compiled(
-        mod.exports,
-        mod.require,
-        mod,
-        mod.filename,
-        dirname(mod.filename),
-      );
-    } catch (error: any) {
-      if (opts.requireCache) {
-        delete nativeRequire.cache[filename];
-      }
-      opts.onError!(error);
-    }
-
-    // Check for parse errors
-    if (mod.exports && mod.exports.__JITI_ERROR__) {
-      const { filename, line, column, code, message } =
-        mod.exports.__JITI_ERROR__;
-      const loc = `${filename}:${line}:${column}`;
-      const err = new Error(`${code}: ${message} \n ${loc}`);
-      Error.captureStackTrace(err, jiti);
-      opts.onError!(err);
-    }
-
-    // Set as loaded
-    mod.loaded = true;
-
-    // interopDefault
-    const _exports = _interopDefault(mod.exports);
-
-    // Return exports
-    return _exports;
-  }
-
-  function register() {
-    return addHook(
-      (source: string, filename: string) =>
-        jiti.transform({ source, filename, ts: !!/\.[cm]?ts$/.test(filename) }),
-      { exts: opts.extensions },
-    );
-  }
-
-  jiti.resolve = _resolve;
-  jiti.cache = opts.requireCache ? nativeRequire.cache : {};
-  jiti.extensions = nativeRequire.extensions;
-  jiti.main = nativeRequire.main;
-  jiti.transform = transform;
-  jiti.register = register;
-  jiti.evalModule = evalModule;
-  jiti.import = async (id: string, importOptions?: JITIImportOptions) =>
-    await jiti(id, { _async: true, ...importOptions });
+      ),
+      transform(opts: TransformOptions) {
+        return transform(ctx, opts);
+      },
+      register() {
+        return addHook(
+          (source: string, filename: string) =>
+            transform(ctx, {
+              source,
+              filename,
+              ts: !!/\.[cm]?ts$/.test(filename),
+            }),
+          { exts: ctx.opts.extensions },
+        );
+      },
+      evalModule(source: string, options?: EvalModuleOptions) {
+        return evalModule(ctx, source, options);
+      },
+      async import(id: string, importOptions?: JITIImportOptions) {
+        return await jitiRequire(ctx, id, { _async: true, ...importOptions });
+      },
+    },
+  );
 
   return jiti;
 }

--- a/src/require.ts
+++ b/src/require.ts
@@ -1,0 +1,97 @@
+import { readFileSync } from "node:fs";
+import { builtinModules } from "node:module";
+import { fileURLToPath } from "node:url";
+import { extname } from "pathe";
+import { jitiInteropDefault } from "./utils";
+import { debug } from "./utils";
+import type { JITIImportOptions, Context } from "./types";
+import { jitiResolve } from "./resolve";
+import { evalModule } from "./eval";
+import { nativeImport } from "./esm";
+
+export function jitiRequire(
+  ctx: Context,
+  id: string,
+  importOptions?: JITIImportOptions,
+) {
+  const cache = ctx.parentCache || {};
+
+  // Check for node: and file: protocol
+  if (id.startsWith("node:")) {
+    id = id.slice(5);
+  } else if (id.startsWith("file:")) {
+    id = fileURLToPath(id);
+  }
+
+  // Check for builtin node module like fs
+  if (builtinModules.includes(id) || id === ".pnp.js" /* #24 */) {
+    return ctx.nativeRequire(id);
+  }
+
+  // Experimental Bun support
+  if (ctx.opts.experimentalBun && !ctx.opts.transformOptions) {
+    try {
+      debug(ctx, `[bun] [native] ${id}`);
+      if (importOptions?._async) {
+        return nativeImport(ctx, id).then((m: any) => {
+          if (ctx.opts.requireCache === false) {
+            delete ctx.nativeRequire.cache[id];
+          }
+          return jitiInteropDefault(ctx, m);
+        });
+      } else {
+        const _mod = ctx.nativeRequire(id);
+        if (ctx.opts.requireCache === false) {
+          delete ctx.nativeRequire.cache[id];
+        }
+        return jitiInteropDefault(ctx, _mod);
+      }
+    } catch (error: any) {
+      debug(ctx, `[bun] Using fallback for ${id} because of an error:`, error);
+    }
+  }
+
+  // Resolve path
+  const filename = jitiResolve(ctx, id);
+  const ext = extname(filename);
+
+  // Check for .json modules
+  if (ext === ".json") {
+    debug(ctx, "[json]", filename);
+    const jsonModule = ctx.nativeRequire(id);
+    Object.defineProperty(jsonModule, "default", { value: jsonModule });
+    return jsonModule;
+  }
+
+  // Unknown format
+  if (ext && !ctx.opts.extensions!.includes(ext)) {
+    debug(ctx, "[unknown]", filename);
+    return ctx.nativeRequire(id);
+  }
+
+  // Force native modules
+  if (ctx.isNativeRe.test(filename)) {
+    debug(ctx, "[native]", filename);
+    return ctx.nativeRequire(id);
+  }
+
+  // Check for CJS cache
+  if (cache[filename]) {
+    return jitiInteropDefault(ctx, cache[filename]?.exports);
+  }
+  if (ctx.opts.requireCache && ctx.nativeRequire.cache[filename]) {
+    return jitiInteropDefault(ctx, ctx.nativeRequire.cache[filename]?.exports);
+  }
+
+  // Read source
+  const source = readFileSync(filename, "utf8");
+
+  // Evaluate module
+  return evalModule(ctx, source, {
+    id,
+    filename,
+    ext,
+    cache,
+    async: importOptions?._async ?? ctx.parentImportOptions?._async,
+  });
+}

--- a/src/resolve.ts
+++ b/src/resolve.ts
@@ -1,0 +1,80 @@
+import { resolveAlias } from "pathe/utils";
+import { resolvePathSync } from "mlly";
+import type { Context } from "./types";
+
+const JS_EXT_RE = /\.(c|m)?j(sx?)$/;
+const TS_EXT_RE = /\.(c|m)?t(sx?)$/;
+
+export function jitiResolve(
+  ctx: Context,
+  id: string,
+  options?: { paths?: string[] },
+) {
+  let resolved, err;
+
+  // Resolve alias
+  if (ctx.alias) {
+    id = resolveAlias(id, ctx.alias);
+  }
+
+  // Try ESM resolve
+  if (ctx.opts.esmResolve) {
+    const conditionSets = [
+      ["node", "require"],
+      ["node", "import"],
+    ];
+    for (const conditions of conditionSets) {
+      try {
+        resolved = resolvePathSync(id, {
+          url: ctx.url,
+          conditions,
+          extensions: ctx.opts.extensions,
+        });
+      } catch (error) {
+        err = error;
+      }
+      if (resolved) {
+        return resolved;
+      }
+    }
+  }
+
+  // Try native require resolve
+  try {
+    return ctx.nativeRequire.resolve(id, options);
+  } catch (error) {
+    err = error;
+  }
+  for (const ext of ctx.additionalExts) {
+    resolved =
+      tryNativeRequireResolve(ctx, id + ext, options) ||
+      tryNativeRequireResolve(ctx, id + "/index" + ext, options);
+    if (resolved) {
+      return resolved;
+    }
+    // Try resolving .ts files with .js extension
+    if (TS_EXT_RE.test(ctx.parentModule?.filename || "")) {
+      resolved = tryNativeRequireResolve(
+        ctx,
+        id.replace(JS_EXT_RE, ".$1t$2"),
+        options,
+      );
+      if (resolved) {
+        return resolved;
+      }
+    }
+  }
+  throw err;
+}
+
+export function tryNativeRequireResolve(
+  ctx: Context,
+  id: string,
+  options?: { paths?: string[] },
+) {
+  try {
+    return ctx.nativeRequire.resolve(id, options);
+  } catch {
+    // Ignore errors
+  }
+}

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -1,0 +1,30 @@
+import { getCache } from "./cache";
+import { Context } from "./types";
+import { debug } from "./utils";
+
+export function transform(ctx: Context, topts: any): string {
+  let code = getCache(ctx, topts.filename, topts.source, () => {
+    const res = ctx.opts.transform!({
+      legacy: ctx.opts.legacy,
+      ...ctx.opts.transformOptions,
+      babel: {
+        ...(ctx.opts.sourceMaps
+          ? {
+              sourceFileName: topts.filename,
+              sourceMaps: "inline",
+            }
+          : {}),
+        ...ctx.opts.transformOptions?.babel,
+      },
+      ...topts,
+    });
+    if (res.error && ctx.opts.debug) {
+      debug(ctx, res.error);
+    }
+    return res.code;
+  });
+  if (code.startsWith("#!")) {
+    code = "// " + code;
+  }
+  return code;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,38 @@
+export type ModuleCache = Record<string, NodeModule>;
+
+export type EvalModuleOptions = Partial<{
+  id: string;
+  filename: string;
+  ext: string;
+  cache: ModuleCache;
+  async: boolean;
+}>;
+
+export interface JITI extends NodeRequire {
+  transform: (opts: TransformOptions) => string;
+  register: () => () => void;
+  evalModule: (source: string, options?: EvalModuleOptions) => unknown;
+  /** @experimental Behavior of `jiti.import` might change in the future. */
+  import: (id: string, importOptions: JITIImportOptions) => Promise<unknown>;
+}
+
+export interface Context {
+  filename: string;
+  url: URL;
+  userOptions: JITIOptions;
+  parentModule?: NodeModule;
+  parentCache?: ModuleCache;
+  parentImportOptions?: JITIImportOptions;
+  opts: JITIOptions;
+  nativeModules: string[];
+  transformModules: string[];
+  isNativeRe: RegExp;
+  isTransformRe: RegExp;
+  alias?: Record<string, string>;
+  additionalExts: string[];
+  nativeRequire: NodeRequire;
+}
+
 export type TransformOptions = {
   source: string;
   filename?: string;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,29 +1,9 @@
 import { lstatSync, accessSync, constants, readFileSync } from "node:fs";
 import { createHash } from "node:crypto";
-import { tmpdir } from "node:os";
 import { join } from "pathe";
 import type { PackageJson } from "pkg-types";
-
-export function getCacheDir() {
-  let _tmpDir = tmpdir();
-
-  // Workaround for pnpm setting an incorrect `TMPDIR`.
-  // Set `JITI_RESPECT_TMPDIR_ENV` to a truthy value to disable this workaround.
-  // https://github.com/pnpm/pnpm/issues/6140
-  // https://github.com/unjs/jiti/issues/120
-  if (
-    process.env.TMPDIR &&
-    _tmpDir === process.cwd() &&
-    !process.env.JITI_RESPECT_TMPDIR_ENV
-  ) {
-    const _env = process.env.TMPDIR;
-    delete process.env.TMPDIR;
-    _tmpDir = tmpdir();
-    process.env.TMPDIR = _env;
-  }
-
-  return join(_tmpDir, "node-jiti");
-}
+import { interopDefault as mllyInteropDefault } from "mlly";
+import { Context } from "./types";
 
 export function isDir(filename: string): boolean {
   try {
@@ -78,4 +58,14 @@ export function wrapModule(source: string, opts?: { async?: boolean }) {
     source = source.replace(/(\s*=\s*)require\(/g, "$1await require(");
   }
   return `(${opts?.async ? "async " : ""}function (exports, require, module, __filename, __dirname) { ${source}\n});`;
+}
+
+export function debug(ctx: Context, ...args: string[]) {
+  if (ctx.opts.debug) {
+    console.log("[jiti]", ...args);
+  }
+}
+
+export function jitiInteropDefault(ctx: Context, mod: any) {
+  return ctx.opts.interopDefault ? mllyInteropDefault(mod) : mod;
 }

--- a/test/__snapshots__/fixtures.test.ts.snap
+++ b/test/__snapshots__/fixtures.test.ts.snap
@@ -16,12 +16,12 @@ import.meta.env?.TEST true"
 exports[`fixtures > error-parse > stderr 1`] = `
 "Error: ParseError: \`import\` can only be used in \`import 
  <cwd>/index.ts
-    at <root>/dist/jiti.js
+    at Function.<anonymous> (<root>/dist/jiti)
     at Generator.next (<anonymous>)
     at <root>/dist/jiti.js
     at new Promise (<anonymous>)
     at __awaiter (<root>/dist/jiti)
-    at jiti.import (<root>/dist/jiti)
+    at Function.import (<root>/dist/jiti)
     at Object.<anonymous> (<root>/bin/jiti)
     at Module._compile (internal/modules/cjs/loader)
     at Module._extensions..js (internal/modules/cjs/loader)
@@ -44,13 +44,13 @@ TypeError: The "listener" argument must be of type function. Received undefined
     at process.addListener (events)
     at <cwd>/index.ts
     at evalModule (<root>/dist/jiti)
-    at jiti (<root>/dist/jiti)
-    at <root>/dist/jiti.js
+    at jitiRequire (<root>/dist/jiti)
+    at Function.<anonymous> (<root>/dist/jiti)
     at Generator.next (<anonymous>)
     at <root>/dist/jiti.js
     at new Promise (<anonymous>)
     at __awaiter (<root>/dist/jiti)
-    at jiti.import (<root>/dist/jiti)
+    at Function.import (<root>/dist/jiti)
     at Object.<anonymous> (<root>/bin/jiti)
     at Module._compile (internal/modules/cjs/loader)
     at Module._extensions..js (internal/modules/cjs/loader)
@@ -77,13 +77,13 @@ exports[`fixtures > esm > stdout 1`] = `
     'at test (<cwd>/test)',
     'at <cwd>/index.js',
     'at evalModule (<root>/dist/jiti)',
-    'at jiti (<root>/dist/jiti)',
-    'at <root>/dist/jiti.js',
+    'at jitiRequire (<root>/dist/jiti)',
+    'at Function.<anonymous> (<root>/dist/jiti)',
     'at Generator.next (<anonymous>)',
     'at <root>/dist/jiti.js',
     'at new Promise (<anonymous>)',
     'at __awaiter (<root>/dist/jiti)',
-    'at jiti.import (<root>/dist/jiti)',
+    'at Function.import (<root>/dist/jiti)',
     'at Object.<anonymous> (<root>/bin/jiti)',
     'at Module._compile (internal/modules/cjs/loader)',
     'at Module._extensions..js (internal/modules/cjs/loader)',

--- a/test/fixtures.test.ts
+++ b/test/fixtures.test.ts
@@ -33,6 +33,7 @@ describe("fixtures", async () => {
             .replace(/Node.js v[\d.]+/, "Node.js v<version>")
             .replace(/ParseError: \w:\/:\s+/, "ParseError: ") // Unknown chars in Windows
             .replace("TypeError [ERR_INVALID_ARG_TYPE]:", "TypeError:")
+            .replace("eval_evalModule", "evalModule")
             // Node 18
             .replace(
               "  ErrorCaptureStackTrace(err);",

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, beforeEach, it, expect, vi } from "vitest";
 import { isWindows } from "std-env";
-import { getCacheDir } from "../src/utils";
+import { getCacheDir } from "../src/cache";
 
 describe("utils", () => {
   describe.skipIf(isWindows)("getCacheDir", () => {


### PR DESCRIPTION
This PR splits jiti logic into more maintainable logical utils sharing a single context per instance.

As a result of this PR adds a few more **eager** computes on context which later could be converted to lazy initialized but reducing the amount of closure creations should help save more memory, especially with long-chain imports.