### PR TITLE
fix(types): fix type exports

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,0 +1,19 @@
+import {
+  JITI,
+  JITIImportOptions,
+  JITIOptions,
+  ModuleCache,
+  TransformOptions,
+} from "../dist/types.js";
+
+export = createJITI;
+declare function createJITI(
+  filename: string,
+  userOptions?: JITIOptions,
+  parentModule?: NodeModule,
+  parentCache?: ModuleCache,
+  parentImportOptions?: JITIImportOptions,
+): JITI;
+declare namespace createJITI {
+  export type { JITI, JITIOptions, TransformOptions };
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "repository": "unjs/jiti",
   "license": "MIT",
   "main": "./lib/index.js",
-  "types": "dist/jiti.d.ts",
   "bin": "bin/jiti.js",
   "files": [
     "lib",


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/twoslashes/twoslash/pull/42#discussion_r1631001129

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Jiti uses a special build step to compile the default export to `export =`. The generated type definitions don’t match this. To resolve this, a manual type declaration file was added.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
