### PR TITLE
 fix: use internal cached modules only if loaded

### DIFF
--- a/src/jiti.ts
+++ b/src/jiti.ts
@@ -336,7 +336,7 @@ export default function createJITI(
     }
 
     // Check for CJS cache
-    if (cache[filename]) {
+    if (cache[filename] && cache[filename].loaded !== false) {
       return _interopDefault(cache[filename]?.exports);
     }
     if (opts.requireCache && nativeRequire.cache[filename]) {


### PR DESCRIPTION
This PR fixes a race condition that when importing the same `id` in parallel from several places (using `await import()`) the jiti was picking the (still) evaluating module without valid exports.

---

Context: Found it while investigating https://github.com/nuxt/nuxt/pull/27479, however this issue is just likely simply revealed with other perf improvements that increased the chance of this race.