### PR TITLE
fix: use internal cached modules only if loaded

### DIFF
--- a/src/jiti.ts
+++ b/src/jiti.ts
@@ -336,7 +336,12 @@ export default function createJITI(
     }
 
     // Check for CJS cache
-    if (cache[filename]) {
+    if (
+      cache[filename] &&
+      cache[filename].loaded === false &&
+      (!parentModule ||
+        parentModule.loaded === false) /* allow circular resolution */
+    ) {
       return _interopDefault(cache[filename]?.exports);
     }
     if (opts.requireCache && nativeRequire.cache[filename]) {

--- a/src/jiti.ts
+++ b/src/jiti.ts
@@ -338,9 +338,8 @@ export default function createJITI(
     // Check for CJS cache
     if (
       cache[filename] &&
-      cache[filename].loaded === false &&
-      (!parentModule ||
-        parentModule.loaded === false) /* allow circular resolution */
+      (cache[filename].loaded === true || // Either module is fully loaded
+        parentModule?.loaded === false) // Or it's a circular dependency (parent is not loaded yet)
     ) {
       return _interopDefault(cache[filename]?.exports);
     }


### PR DESCRIPTION
rework of #245

detect cache race conditions while still handling circular resolution (when parent is not in loaded state)