### PR TITLE
refactor: remove legacy node syntax polyfills

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,8 +41,6 @@
     "@babel/plugin-syntax-class-properties": "^7.12.13",
     "@babel/plugin-syntax-import-assertions": "^7.24.7",
     "@babel/plugin-transform-export-namespace-from": "^7.24.7",
-    "@babel/plugin-transform-nullish-coalescing-operator": "^7.24.7",
-    "@babel/plugin-transform-optional-chaining": "^7.24.7",
     "@babel/plugin-transform-typescript": "^7.24.7",
     "@babel/preset-typescript": "^7.24.7",
     "@babel/template": "^7.24.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,12 +32,6 @@ importers:
       '@babel/plugin-transform-export-namespace-from':
         specifier: ^7.24.7
         version: 7.24.7(@babel/core@7.24.7)
-      '@babel/plugin-transform-nullish-coalescing-operator':
-        specifier: ^7.24.7
-        version: 7.24.7(@babel/core@7.24.7)
-      '@babel/plugin-transform-optional-chaining':
-        specifier: ^7.24.7
-        version: 7.24.7(@babel/core@7.24.7)
       '@babel/plugin-transform-typescript':
         specifier: ^7.24.7
         version: 7.24.7(@babel/core@7.24.7)
@@ -329,16 +323,6 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3':
-    resolution: {integrity: sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-syntax-optional-chaining@7.8.3':
-    resolution: {integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
   '@babel/plugin-syntax-typescript@7.24.7':
     resolution: {integrity: sha512-c/+fVeJBB0FeKsFvwytYiUD+LBvhHjGSI0g446PRGdSVGZLRNArBUno2PETbAly3tpiNAQR5XaZ+JslxkotsbA==}
     engines: {node: '>=6.9.0'}
@@ -353,18 +337,6 @@ packages:
 
   '@babel/plugin-transform-modules-commonjs@7.24.7':
     resolution: {integrity: sha512-iFI8GDxtevHJ/Z22J5xQpVqFLlMNstcLXh994xifFwxxGslr2ZXXLWgtBeLctOD63UFDArdvN6Tg8RFw+aEmjQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-nullish-coalescing-operator@7.24.7':
-    resolution: {integrity: sha512-Ts7xQVk1OEocqzm8rHMXHlxvsfZ0cEF2yomUqpKENHWMF4zKk175Y4q8H5knJes6PgYad50uuRmt3UJuhBw8pQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-optional-chaining@7.24.7':
-    resolution: {integrity: sha512-tK+0N9yd4j+x/4hxF3F0e0fu/VdcxU18y5SevtyM/PCFlQvXbR0Zmlo2eBrKtVipGNFzpq56o8WsIIKcJFUCRQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -2652,16 +2624,6 @@ snapshots:
       '@babel/core': 7.24.7
       '@babel/helper-plugin-utils': 7.24.7
 
-  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.24.7)':
-    dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
-
-  '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.24.7)':
-    dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
-
   '@babel/plugin-syntax-typescript@7.24.7(@babel/core@7.24.7)':
     dependencies:
       '@babel/core': 7.24.7
@@ -2679,21 +2641,6 @@ snapshots:
       '@babel/helper-module-transforms': 7.24.7(@babel/core@7.24.7)
       '@babel/helper-plugin-utils': 7.24.7
       '@babel/helper-simple-access': 7.24.7
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-transform-nullish-coalescing-operator@7.24.7(@babel/core@7.24.7)':
-    dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.24.7)
-
-  '@babel/plugin-transform-optional-chaining@7.24.7(@babel/core@7.24.7)':
-    dependencies:
-      '@babel/core': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.7
-      '@babel/helper-skip-transparent-expression-wrappers': 7.24.7
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.24.7)
     transitivePeerDependencies:
       - supports-color
 

--- a/src/babel.ts
+++ b/src/babel.ts
@@ -41,13 +41,6 @@ export default function transform(opts: TransformOptions): TRANSFORM_RESULT {
     _opts.plugins.push(require("@babel/plugin-syntax-import-assertions"));
   }
 
-  if (opts.legacy) {
-    _opts.plugins.push(
-      require("@babel/plugin-transform-nullish-coalescing-operator"),
-    );
-    _opts.plugins.push(require("@babel/plugin-transform-optional-chaining"));
-  }
-
   if (opts.babel && Array.isArray(opts.babel.plugins)) {
     _opts.plugins?.push(...opts.babel.plugins);
   }

--- a/src/eval.ts
+++ b/src/eval.ts
@@ -5,7 +5,6 @@ import { dirname, basename, extname } from "pathe";
 import { hasESMSyntax } from "mlly";
 import {
   debug,
-  detectLegacySyntax,
   jitiInteropDefault,
   readNearestPackageJSON,
   wrapModule,
@@ -43,9 +42,7 @@ export function evalModule(
     (isTypescript ||
       isESM ||
       ctx.isTransformRe.test(filename) ||
-      hasESMSyntax(source) ||
-      (ctx.opts.legacy && detectLegacySyntax(source)));
-
+      hasESMSyntax(source));
   const start = performance.now();
   if (needsTranspile) {
     source = transform(ctx, {

--- a/src/options.ts
+++ b/src/options.ts
@@ -20,7 +20,6 @@ const jitiDefaults: JITIOptions = {
   sourceMaps: _EnvSourceMaps === undefined ? false : !!_EnvSourceMaps,
   interopDefault: false,
   cacheVersion: "7",
-  legacy: lt(process.version || "0.0.0", "14.0.0"),
   extensions: [".js", ".mjs", ".cjs", ".ts", ".mts", ".cts", ".json"],
   alias: _EnvAlias,
   nativeModules: _EnvNative || [],
@@ -32,9 +31,6 @@ export function resolveJitiOptions(userOptions: JITIOptions): JITIOptions {
   const opts: JITIOptions = { ...jitiDefaults, ...userOptions };
 
   // Cache dependencies
-  if (opts.legacy) {
-    opts.cacheVersion += "-legacy";
-  }
   if (opts.transformOptions) {
     opts.cacheVersion += "-" + objectHash(opts.transformOptions);
   }

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -5,7 +5,6 @@ import { debug } from "./utils";
 export function transform(ctx: Context, topts: any): string {
   let code = getCache(ctx, topts.filename, topts.source, () => {
     const res = ctx.opts.transform!({
-      legacy: ctx.opts.legacy,
       ...ctx.opts.transformOptions,
       babel: {
         ...(ctx.opts.sourceMaps

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,7 +41,6 @@ export type TransformOptions = {
   filename?: string;
   ts?: boolean;
   retainLines?: boolean;
-  legacy?: boolean;
   async?: boolean;
   [key: string]: any;
 };
@@ -60,7 +59,6 @@ export type JITIOptions = {
   v8cache?: boolean;
   interopDefault?: boolean;
   cacheVersion?: string;
-  legacy?: boolean;
   extensions?: string[];
   transformOptions?: Omit<TransformOptions, "source">;
   alias?: Record<string, string>;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -29,10 +29,6 @@ export function md5(content: string, len = 8) {
   return createHash("md5").update(content).digest("hex").slice(0, len);
 }
 
-export function detectLegacySyntax(code: string) {
-  return code.match(/\?\.|\?\?/);
-}
-
 export function isObject(val: any) {
   return val !== null && typeof val === "object";
 }


### PR DESCRIPTION
This PR removed jiti support for Node.js 12 without bullish coalescing operator and optional chaining syntax support for jiti v2