### PR TITLE
refactor: use more clear `fsCache` and `moduleCache` options

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,15 +111,29 @@ const unregister = jiti.register();
 
 Enable debug to see which files are transpiled
 
-### `cache`
+### `fsCache`
 
 - Type: Boolean | String
 - Default: `true`
-- Environment Variable: `JITI_CACHE`
+- Environment Variable: `JITI_FS_CACHE`
 
-Use transpile cache
+Filesystem source cache (enabled by default)
 
-If set to `true` will use `node_modules/.cache/jiti` (if exists) or `{TMP_DIR}/node-jiti`
+By default (when is `true`), jiti uses `node_modules/.cache/jiti` (if exists) or `{TMP_DIR}/node-jiti`.
+
+**Note:** It is recommended to keep this option enabled for better performance.
+
+### `moduleCache`
+
+- Type: String
+- Default: `true`
+- Environment Variable: `JITI_MODULE_CACHE`
+
+Runtime module cache (enabled by default).
+
+Disabling allows editing code and importing same module multiple times.
+
+When enabled, jiti integrates with Node.js native CommonJS cache store.
 
 ### `transform`
 

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -31,6 +31,36 @@ export interface Jiti extends NodeRequire {
  */
 export interface JitiOptions {
   /**
+   * Filesystem source cache (enabled by default)
+   *
+   * An string can be passed to set the custom cache directory.
+   *
+   * By default (when is `true`), jiti uses  `node_modules/.cache/jiti` (if exists) or `{TMP_DIR}/node-jiti`.
+   *
+   * This option can also be disabled using `JITI_FS_CACHE=false` environment variable.
+   *
+   * **Note:** It is recommended to keep this option enabled for better performance.
+   */
+  fsCache?: boolean | string;
+
+  /** @deprecated Use `fsCache` option. */
+  cache?: boolean | string;
+
+  /**
+   * Runtime module cache (enabled by default)
+   *
+   * Disabling allows editing code and importing same module multiple times.
+   *
+   * When enabled, jiti integrates with Node.js native CommonJS cache store.
+   *
+   * This option can also be disabled using `JITI_MODULE_CACHE=false` environment variable.
+   */
+  moduleCache?: boolean;
+
+  /** @deprecated Use `moduleCache` option.  */
+  requireCache?: boolean;
+
+  /**
    * Custom transform function
    */
   transform?: (opts: TransformOptions) => TransformResult;
@@ -43,33 +73,11 @@ export interface JitiOptions {
   debug?: boolean;
 
   /**
-   * Enable hard-source caching with HMR support (enabled by default).
-   *
-   * An string can be passed to set the custom cache directory.
-   *
-   * By default (when is `true`), jiti uses  `node_modules/.cache/jiti` (if exists) or `{TMP_DIR}/node-jiti`
-   *
-   * Can also be disabled using `JITI_CACHE=0` environment variable.
-   *
-   * **Note:** It is recommended to keep this option enabled for performance.
-   */
-  cache?: boolean | string;
-
-  /**
    * Enable sourcemaps (enabled by default)
    *
    * Can also be disabled using `JITI_SOURCE_MAPS=0` environment variable.
    */
   sourceMaps?: boolean;
-
-  /**
-   * Enable CommonJS require cache integration (enabled by default)
-   *
-   * Disabling allows requiring same module multiple times.
-   *
-   * Can also be disabled using `JITI_REQUIRE_CACHE=0` environment variable.
-   */
-  requireCache?: boolean;
 
   /**
    * Interop default export (disabled by default)

--- a/src/eval.ts
+++ b/src/eval.ts
@@ -108,7 +108,7 @@ export function evalModule(
 
   // Set CJS cache before eval
   cache[filename] = mod;
-  if (ctx.opts.requireCache) {
+  if (ctx.opts.moduleCache) {
     ctx.nativeRequire.cache[filename] = mod;
   }
 
@@ -124,7 +124,7 @@ export function evalModule(
       },
     );
   } catch (error: any) {
-    if (ctx.opts.requireCache) {
+    if (ctx.opts.moduleCache) {
       delete ctx.nativeRequire.cache[filename];
     }
     ctx.onError!(error);
@@ -142,7 +142,7 @@ export function evalModule(
       _jiti.import,
     );
   } catch (error: any) {
-    if (ctx.opts.requireCache) {
+    if (ctx.opts.moduleCache) {
       delete ctx.nativeRequire.cache[filename];
     }
     ctx.onError!(error);

--- a/src/jiti.ts
+++ b/src/jiti.ts
@@ -101,7 +101,7 @@ export default function createJiti(
       return jitiRequire(ctx, id, false /* no async */);
     },
     {
-      cache: opts.requireCache ? nativeRequire.cache : {},
+      cache: opts.moduleCache ? nativeRequire.cache : Object.create(null),
       extensions: nativeRequire.extensions,
       main: nativeRequire.main,
       resolve: Object.assign(

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,38 +1,48 @@
 import { destr } from "destr";
-import objectHash from "object-hash";
 
 import type { JitiOptions } from "./types";
 
-const _EnvDebug = destr<boolean>(process.env.JITI_DEBUG);
-const _EnvCache = destr<boolean>(process.env.JITI_CACHE);
-const _EnvRequireCache = destr<boolean>(process.env.JITI_REQUIRE_CACHE);
-const _EnvSourceMaps = destr<boolean>(process.env.JITI_SOURCE_MAPS);
-const _EnvAlias = destr<Record<string, string>>(process.env.JITI_ALIAS);
-const _EnvTransform = destr<string[]>(process.env.JITI_TRANSFORM_MODULES);
-const _EnvNative = destr<string[]>(process.env.JITI_NATIVE_MODULES);
-const _ExpBun = destr<string[]>(process.env.JITI_EXPERIMENTAL_BUN);
-
-const jitiDefaults: JitiOptions = {
-  debug: _EnvDebug,
-  cache: _EnvCache === undefined ? true : !!_EnvCache,
-  requireCache: _EnvRequireCache === undefined ? true : !!_EnvRequireCache,
-  sourceMaps: _EnvSourceMaps === undefined ? false : !!_EnvSourceMaps,
-  interopDefault: false,
-  cacheVersion: "8",
-  extensions: [".js", ".mjs", ".cjs", ".ts", ".mts", ".cts", ".json"],
-  alias: _EnvAlias,
-  nativeModules: _EnvNative || [],
-  transformModules: _EnvTransform || [],
-  experimentalBun: _ExpBun === undefined ? !!process.versions.bun : !!_ExpBun,
-};
-
 export function resolveJitiOptions(userOptions: JitiOptions): JitiOptions {
-  const opts: JitiOptions = { ...jitiDefaults, ...userOptions };
+  const _EnvFSCache =
+    destr<boolean>(process.env.JITI_FS_CACHE) ??
+    destr<boolean>(process.env.JITI_CACHE); // Backward compatibility
+  const _EnvModuleCache =
+    destr<boolean>(process.env.JITI_MODULE_CACHE) ??
+    destr<boolean>(process.env.JITI_REQUIRE_CACHE); // Backward compatibility
 
-  // Cache dependencies
-  if (opts.transformOptions) {
-    opts.cacheVersion += "-" + objectHash(opts.transformOptions);
+  const _EnvDebug = destr<boolean>(process.env.JITI_DEBUG);
+  const _EnvSourceMaps = destr<boolean>(process.env.JITI_SOURCE_MAPS);
+  const _EnvAlias = destr<Record<string, string>>(process.env.JITI_ALIAS);
+  const _EnvTransform = destr<string[]>(process.env.JITI_TRANSFORM_MODULES);
+  const _EnvNative = destr<string[]>(process.env.JITI_NATIVE_MODULES);
+  const _ExpBun = destr<string[]>(process.env.JITI_EXPERIMENTAL_BUN);
+
+  const jitiDefaults: JitiOptions = {
+    fsCache: _EnvFSCache === undefined ? true : !!_EnvFSCache,
+    moduleCache: _EnvModuleCache === undefined ? true : !!_EnvModuleCache,
+    debug: _EnvDebug,
+    sourceMaps: _EnvSourceMaps === undefined ? false : !!_EnvSourceMaps,
+    interopDefault: false,
+    extensions: [".js", ".mjs", ".cjs", ".ts", ".mts", ".cts", ".json"],
+    alias: _EnvAlias,
+    nativeModules: _EnvNative || [],
+    transformModules: _EnvTransform || [],
+    experimentalBun: _ExpBun === undefined ? !!process.versions.bun : !!_ExpBun,
+  };
+
+  const deprecateOvverides: JitiOptions = {};
+  if (userOptions.cache) {
+    deprecateOvverides.fsCache = userOptions.cache;
   }
+  if (userOptions.requireCache) {
+    deprecateOvverides.requireCache = userOptions.requireCache;
+  }
+
+  const opts: JitiOptions = {
+    ...jitiDefaults,
+    ...deprecateOvverides,
+    ...userOptions,
+  };
 
   return opts;
 }

--- a/src/options.ts
+++ b/src/options.ts
@@ -30,17 +30,17 @@ export function resolveJitiOptions(userOptions: JitiOptions): JitiOptions {
     experimentalBun: _ExpBun === undefined ? !!process.versions.bun : !!_ExpBun,
   };
 
-  const deprecateOvverides: JitiOptions = {};
+  const deprecatOverrides: JitiOptions = {};
   if (userOptions.cache) {
-    deprecateOvverides.fsCache = userOptions.cache;
+    deprecatOverrides.fsCache = userOptions.cache;
   }
   if (userOptions.requireCache) {
-    deprecateOvverides.requireCache = userOptions.requireCache;
+    deprecatOverrides.moduleCache = userOptions.requireCache;
   }
 
   const opts: JitiOptions = {
     ...jitiDefaults,
-    ...deprecateOvverides,
+    ...deprecatOverrides,
     ...userOptions,
   };
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -18,10 +18,10 @@ export function resolveJitiOptions(userOptions: JitiOptions): JitiOptions {
   const _ExpBun = destr<string[]>(process.env.JITI_EXPERIMENTAL_BUN);
 
   const jitiDefaults: JitiOptions = {
-    fsCache: _EnvFSCache === undefined ? true : !!_EnvFSCache,
-    moduleCache: _EnvModuleCache === undefined ? true : !!_EnvModuleCache,
+    fsCache: _EnvFSCache ?? true,
+    moduleCache: _EnvModuleCache ?? true,
     debug: _EnvDebug,
-    sourceMaps: _EnvSourceMaps === undefined ? false : !!_EnvSourceMaps,
+    sourceMaps: _EnvSourceMaps ?? false,
     interopDefault: false,
     extensions: [".js", ".mjs", ".cjs", ".ts", ".mts", ".cts", ".json"],
     alias: _EnvAlias,
@@ -31,10 +31,10 @@ export function resolveJitiOptions(userOptions: JitiOptions): JitiOptions {
   };
 
   const deprecatOverrides: JitiOptions = {};
-  if (userOptions.cache) {
+  if (userOptions.cache !== undefined) {
     deprecatOverrides.fsCache = userOptions.cache;
   }
-  if (userOptions.requireCache) {
+  if (userOptions.requireCache !== undefined) {
     deprecatOverrides.moduleCache = userOptions.requireCache;
   }
 

--- a/src/require.ts
+++ b/src/require.ts
@@ -30,14 +30,14 @@ export function jitiRequire(ctx: Context, id: string, async: boolean) {
       id = jitiResolve(ctx, id);
       if (async && ctx.nativeImport) {
         return ctx.nativeImport(id).then((m: any) => {
-          if (ctx.opts.requireCache === false) {
+          if (ctx.opts.moduleCache === false) {
             delete ctx.nativeRequire.cache[id];
           }
           return jitiInteropDefault(ctx, m);
         });
       } else {
         const _mod = ctx.nativeRequire(id);
-        if (ctx.opts.requireCache === false) {
+        if (ctx.opts.moduleCache === false) {
           delete ctx.nativeRequire.cache[id];
         }
         return jitiInteropDefault(ctx, _mod);
@@ -76,11 +76,11 @@ export function jitiRequire(ctx: Context, id: string, async: boolean) {
     return nativeImportOrRequire(ctx, id, async);
   }
 
-  // Check for CJS cache
+  // Check for runtime cache
   if (cache[filename]) {
     return jitiInteropDefault(ctx, cache[filename]?.exports);
   }
-  if (ctx.opts.requireCache && ctx.nativeRequire.cache[filename]) {
+  if (ctx.opts.moduleCache && ctx.nativeRequire.cache[filename]) {
     return jitiInteropDefault(ctx, ctx.nativeRequire.cache[filename]?.exports);
   }
 

--- a/test/bun.test.ts
+++ b/test/bun.test.ts
@@ -13,8 +13,8 @@ const fixtures = await readdir(fixturesDir);
 const _jiti = createJiti(fixturesDir, {
   debug: true,
   interopDefault: true,
-  requireCache: false,
-  cache: false,
+  fsCache: false,
+  moduleCache: false,
 });
 
 for (const fixture of fixtures) {


### PR DESCRIPTION
`cache` / `requireCache` options where confusing in previous versions of jiti and often the perf benefits of disk cache was being missed because usages was disabling fs caching wrongly assuming it stops HMR support.

Config deprecations: 
- `cache` ~> `fsCache`
- `requireCache` ~> `moduleCache`

This PR includes some other cache-related minor changes.