### PR TITLE
fix: resolve with esm conditions in async context

### DIFF
--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -13,6 +13,10 @@ export interface Jiti extends NodeRequire {
    */
   import: (id: string) => Promise<unknown>;
   /**
+   * Resolve with ESM import conditions.
+   */
+  importResolve: (id: string) => string;
+  /**
    * Transform source code
    */
   transform: (opts: TransformOptions) => string;

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "build": "pnpm clean && NODE_ENV=production pnpm webpack",
     "clean": "rm -rf dist",
     "dev": "pnpm clean && pnpm webpack --watch",
-    "jiti": "JITI_DEBUG=1 JITI_CACHE=false JITI_REQUIRE_CACHE=false ./lib/jiti-cli.mjs",
+    "jiti": "JITI_DEBUG=1 ./lib/jiti-cli.mjs",
     "lint": "eslint . && prettier -c src lib test stubs",
     "lint:fix": "eslint --fix . && prettier -w src lib test stubs",
     "release": "pnpm build && pnpm test && changelogen --release --prerelease --push --publish --publishTag 2x",

--- a/src/eval.ts
+++ b/src/eval.ts
@@ -25,8 +25,9 @@ export function evalModule(
     evalOptions.id ||
     (evalOptions.filename
       ? basename(evalOptions.filename)
-      : `_jitiEval.${evalOptions.ext || ".js"}`);
-  const filename = evalOptions.filename || jitiResolve(ctx, id);
+      : `_jitiEval.${evalOptions.ext || (evalOptions.async ? "mjs" : "js")}`);
+  const filename =
+    evalOptions.filename || jitiResolve(ctx, id, { async: evalOptions.async });
   const ext = evalOptions.ext || extname(filename);
   const cache = (evalOptions.cache || ctx.parentCache || {}) as ModuleCache;
 

--- a/src/jiti.ts
+++ b/src/jiti.ts
@@ -106,7 +106,7 @@ export default function createJiti(
       main: nativeRequire.main,
       resolve: Object.assign(
         function resolve(path: string) {
-          return jitiResolve(ctx, path);
+          return jitiResolve(ctx, path, { async: false });
         },
         {
           paths: nativeRequire.resolve.paths,
@@ -132,6 +132,9 @@ export default function createJiti(
       },
       async import(id: string) {
         return await jitiRequire(ctx, id, true /* async */);
+      },
+      importResolve(id: string) {
+        return jitiResolve(ctx, id, { async: true });
       },
     },
   );

--- a/src/require.ts
+++ b/src/require.ts
@@ -27,7 +27,7 @@ export function jitiRequire(ctx: Context, id: string, async: boolean) {
   if (ctx.opts.experimentalBun && !ctx.opts.transformOptions) {
     try {
       debug(ctx, `[bun] [native] ${id}`);
-      id = jitiResolve(ctx, id);
+      id = jitiResolve(ctx, id, { async });
       if (async && ctx.nativeImport) {
         return ctx.nativeImport(id).then((m: any) => {
           if (ctx.opts.moduleCache === false) {
@@ -48,7 +48,7 @@ export function jitiRequire(ctx: Context, id: string, async: boolean) {
   }
 
   // Resolve path
-  const filename = jitiResolve(ctx, id);
+  const filename = jitiResolve(ctx, id, { async });
   const ext = extname(filename);
 
   // Check for .json modules

--- a/src/resolve.ts
+++ b/src/resolve.ts
@@ -8,8 +8,7 @@ const TS_EXT_RE = /\.(c|m)?t(sx?)$/;
 export function jitiResolve(
   ctx: Context,
   id: string,
-  options?: { paths?: string[] },
-  async?: boolean,
+  options?: { paths?: string[]; async?: boolean },
 ) {
   let resolved, err;
 
@@ -19,7 +18,7 @@ export function jitiResolve(
   }
 
   // Try resolving with ESM compatible Node.js resolution in async context
-  const conditionSets = async
+  const conditionSets = options?.async
     ? [
         ["node", "import"],
         ["node", "require"],


### PR DESCRIPTION
In async mode, jiti should always resolve with async/esm conditions.

This PR also exposes jiti.importResolve` utility that uses esm condition in contrast to `jiti.resolve` that is CJS.