### PR TITLE
perf: reduce overhead of sub jiti instances

### DIFF
--- a/src/eval.ts
+++ b/src/eval.ts
@@ -92,12 +92,17 @@ export function evalModule(
     }
   }
 
-  const _jiti = createJiti(filename, ctx.opts, {
-    nativeImport: ctx.nativeImport,
-    onError: ctx.onError,
-    parentModule: mod,
-    parentCache: cache,
-  });
+  const _jiti = createJiti(
+    filename,
+    ctx.opts,
+    {
+      nativeImport: ctx.nativeImport,
+      onError: ctx.onError,
+      parentModule: mod,
+      parentCache: cache,
+    },
+    true /* isNested */,
+  );
 
   mod.require = _jiti;
 

--- a/src/jiti.ts
+++ b/src/jiti.ts
@@ -25,13 +25,13 @@ const isWindows = platform() === "win32";
 export default function createJiti(
   filename: string,
   userOptions: JitiOptions = {},
-  _internal?: Pick<
+  parentJiti?: Pick<
     Context,
     "parentModule" | "parentCache" | "nativeImport" | "onError"
   >,
 ): Jiti {
   // Resolve options
-  const opts = resolveJitiOptions(userOptions);
+  const opts = parentJiti ? userOptions : resolveJitiOptions(userOptions);
 
   // Normalize aliases (and disable if non given)
   const alias =
@@ -86,14 +86,16 @@ export default function createJiti(
     isTransformRe,
     additionalExts,
     nativeRequire,
-    onError: _internal?.onError,
-    parentModule: _internal?.parentModule,
-    parentCache: _internal?.parentCache,
-    nativeImport: _internal?.nativeImport,
+    onError: parentJiti?.onError,
+    parentModule: parentJiti?.parentModule,
+    parentCache: parentJiti?.parentCache,
+    nativeImport: parentJiti?.nativeImport,
   };
 
   // Prepare cache dir
-  prepareCacheDir(ctx);
+  if (!parentJiti) {
+    prepareCacheDir(ctx);
+  }
 
   // Create jiti instance
   const jiti: Jiti = Object.assign(

--- a/src/jiti.ts
+++ b/src/jiti.ts
@@ -25,13 +25,14 @@ const isWindows = platform() === "win32";
 export default function createJiti(
   filename: string,
   userOptions: JitiOptions = {},
-  parentJiti?: Pick<
+  parentContext?: Pick<
     Context,
     "parentModule" | "parentCache" | "nativeImport" | "onError"
   >,
+  isNested = false,
 ): Jiti {
   // Resolve options
-  const opts = parentJiti ? userOptions : resolveJitiOptions(userOptions);
+  const opts = isNested ? userOptions : resolveJitiOptions(userOptions);
 
   // Normalize aliases (and disable if non given)
   const alias =
@@ -86,14 +87,14 @@ export default function createJiti(
     isTransformRe,
     additionalExts,
     nativeRequire,
-    onError: parentJiti?.onError,
-    parentModule: parentJiti?.parentModule,
-    parentCache: parentJiti?.parentCache,
-    nativeImport: parentJiti?.nativeImport,
+    onError: parentContext?.onError,
+    parentModule: parentContext?.parentModule,
+    parentCache: parentContext?.parentCache,
+    nativeImport: parentContext?.nativeImport,
   };
 
   // Prepare cache dir
-  if (!parentJiti) {
+  if (!isNested) {
     prepareCacheDir(ctx);
   }
 


### PR DESCRIPTION
jiti creates a new instance when evaluating nested modules.

Some operations can be avoided and this PR avoids cache + option resolution. (more could be done but needs more refactor!)