### PR TITLE
feat: allow `try` and other resolve options for `import`/`esmResolve`

### DIFF
--- a/lib/jiti-hooks.mjs
+++ b/lib/jiti-hooks.mjs
@@ -17,7 +17,8 @@ export async function resolve(specifier, context, nextResolve) {
   if (_shouldSkip(specifier)) {
     return nextResolve(specifier, context);
   }
-  const resolvedPath = jiti.esmResolve(specifier, context?.parentURL, {
+  const resolvedPath = jiti.esmResolve(specifier, {
+    parentURL: context?.parentURL,
     conditions: context?.conditions,
   });
   return {

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -11,19 +11,21 @@ export interface Jiti extends NodeRequire {
   /**
    * ESM import a module with additional Typescript and ESM compatibility.
    */
-  import: (id: string) => Promise<unknown>;
+  import(id: string, opts?: JitiResolveOptions): Promise<unknown>;
+
   /**
    * Resolve with ESM import conditions.
    */
-  esmResolve: (
+  esmResolve<T extends JitiResolveOptions = JitiResolveOptions>(
     id: string,
-    parentURL?: string,
-    opts?: { conditions?: string[] },
-  ) => string;
+    opts?: T,
+  ): T["try"] extends true ? string | undefined : string;
+
   /**
    * Transform source code
    */
   transform: (opts: TransformOptions) => string;
+
   /**
    * Evaluate transformed code as a module
    */
@@ -155,4 +157,10 @@ export interface TransformOptions {
 export interface TransformResult {
   code: string;
   error?: any;
+}
+
+export interface JitiResolveOptions {
+  conditions?: string[];
+  parentURL?: string;
+  try?: boolean;
 }

--- a/src/require.ts
+++ b/src/require.ts
@@ -32,6 +32,9 @@ export function jitiRequire(
     try {
       debug(ctx, "[bun]", "[native]", id);
       id = jitiResolve(ctx, id, opts);
+      if (!id && opts.try) {
+        return undefined;
+      }
       if (opts.async && ctx.nativeImport) {
         return ctx.nativeImport(id).then((m: any) => {
           if (ctx.opts.moduleCache === false) {
@@ -53,6 +56,9 @@ export function jitiRequire(
 
   // Resolve path
   const filename = jitiResolve(ctx, id, opts);
+  if (!filename && opts.try) {
+    return undefined;
+  }
   const ext = extname(filename);
 
   // Check for .json modules

--- a/src/require.ts
+++ b/src/require.ts
@@ -1,17 +1,17 @@
+import type { Context, JitiResolveOptions } from "./types";
 import { readFileSync } from "node:fs";
 import { builtinModules } from "node:module";
 import { fileURLToPath } from "node:url";
 import { extname } from "pathe";
 import { jitiInteropDefault, normalizeWindowsImportId } from "./utils";
 import { debug } from "./utils";
-import type { Context } from "./types";
 import { jitiResolve } from "./resolve";
 import { evalModule } from "./eval";
 
 export function jitiRequire(
   ctx: Context,
   id: string,
-  opts: { async: boolean; try?: boolean },
+  opts: JitiResolveOptions & { async: boolean },
 ) {
   const cache = ctx.parentCache || {};
 

--- a/src/resolve.ts
+++ b/src/resolve.ts
@@ -1,6 +1,6 @@
 import { resolveAlias } from "pathe/utils";
 import { resolvePathSync } from "mlly";
-import type { Context } from "./types";
+import type { Context, JitiResolveOptions } from "./types";
 
 const JS_EXT_RE = /\.(c|m)?j(sx?)$/;
 const TS_EXT_RE = /\.(c|m)?t(sx?)$/;
@@ -8,12 +8,7 @@ const TS_EXT_RE = /\.(c|m)?t(sx?)$/;
 export function jitiResolve(
   ctx: Context,
   id: string,
-  options?: {
-    paths?: string[];
-    async?: boolean;
-    parentURL?: string;
-    conditions?: string[];
-  },
+  options: JitiResolveOptions & { async?: boolean; paths?: string[] },
 ) {
   let resolved, err;
 
@@ -71,6 +66,11 @@ export function jitiResolve(
         return resolved;
       }
     }
+  }
+
+  if (options?.try) {
+    // Well-typed in types.d.ts
+    return undefined as unknown as string;
   }
 
   throw err;

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,7 @@ export type {
   Jiti,
   TransformOptions,
   TransformResult,
+  JitiResolveOptions,
 } from "../lib/types";
 
 export interface Context {


### PR DESCRIPTION
Allow custom resolve options to be passed + common usecase of try import (if module exists)