### PR TITLE
fix: use different cache dir as `jiti` v1

### DIFF
--- a/src/cache.ts
+++ b/src/cache.ts
@@ -67,7 +67,7 @@ export function prepareCacheDir(ctx: Context) {
 export function getCacheDir(ctx: Context) {
   const nmDir = ctx.filename && resolve(ctx.filename, "../node_modules");
   if (nmDir && existsSync(nmDir)) {
-    return join(nmDir, ".cache/jiti");
+    return join(nmDir, ".cache/jiti-v2");
   }
 
   let _tmpDir = tmpdir();
@@ -87,5 +87,5 @@ export function getCacheDir(ctx: Context) {
     process.env.TMPDIR = _env;
   }
 
-  return join(_tmpDir, "jiti");
+  return join(_tmpDir, "jiti-v2");
 }

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -19,25 +19,25 @@ describe("utils", () => {
     it("returns the system's TMPDIR when TMPDIR is not set", () => {
       const originalTmpdir = process.env.TMPDIR;
       delete process.env.TMPDIR;
-      expect(getCacheDir({} as any)).toBe("/tmp/jiti");
+      expect(getCacheDir({} as any)).toBe("/tmp/jiti-v2");
       process.env.TMPDIR = originalTmpdir;
     });
 
     it("returns TMPDIR when TMPDIR is not CWD", () => {
       vi.stubEnv("TMPDIR", notCwd);
-      expect(getCacheDir({} as any)).toBe("/cwd__NOT__/jiti");
+      expect(getCacheDir({} as any)).toBe("/cwd__NOT__/jiti-v2");
     });
 
     it("returns the system's TMPDIR when TMPDIR is CWD", () => {
       vi.stubEnv("TMPDIR", cwd);
-      expect(getCacheDir({} as any)).toBe("/tmp/jiti");
+      expect(getCacheDir({} as any)).toBe("/tmp/jiti-v2");
     });
 
     it("returns TMPDIR when TMPDIR is CWD and TMPDIR is kept", () => {
       vi.stubEnv("TMPDIR", cwd);
       vi.stubEnv("JITI_RESPECT_TMPDIR_ENV", "true");
 
-      expect(getCacheDir({} as any)).toBe("/cwd/jiti");
+      expect(getCacheDir({} as any)).toBe("/cwd/jiti-v2");
     });
   });
 });


### PR DESCRIPTION
As the transform results are different, in cases where a project uses both Jiti v1 and v2 together, the cache will interfere each others 