### PR TITLE
feat: `jiti/native` export

### DIFF
--- a/lib/jiti-native.mjs
+++ b/lib/jiti-native.mjs
@@ -1,25 +1,18 @@
-import _createJiti from "../dist/jiti.cjs";
-
 /**
  * @typedef {import('./types').Jiti} Jiti
  * @typedef {import('./types').JitiOptions} JitiOptions
  */
 
 /**
- * @param {string} message
- */
-function unsupportedError(message) {
-  throw new Error(
-    `[jiti] ${message} (import or require \`jiti/node\` for more features).`,
-  );
-}
-
-/**
  * @param {string} parentURL
- * @param {JitiOptions} opts
+ * @param {JitiOptions} [_opts]
  * @returns {Jiti}
  */
-export function createJiti(parentURL, _opts) {
+export function createJiti(parentURL = "./_.js", _opts) {
+  if (isDir(parentURL)) {
+    parentURL += "/_.js";
+  }
+
   /** @type {Jiti} */
   function jiti() {
     throw unsupportedError(
@@ -33,6 +26,7 @@ export function createJiti(parentURL, _opts) {
 
   jiti.esmResolve = (id, opts) => {
     try {
+      console.log("resolve", { id, from: opts?.parentURL || parentURL });
       return import.meta.resolve(id, opts?.parentURL || parentURL);
     } catch (error) {
       if (opts?.try) {
@@ -75,3 +69,22 @@ export function createJiti(parentURL, _opts) {
 }
 
 export default createJiti;
+
+/**
+ * @param {string} message
+ */
+function unsupportedError(message) {
+  throw new Error(
+    `[jiti] ${message} (import or require \`jiti/node\` for more features).`,
+  );
+}
+
+function isDir(filename) {
+  if (filename instanceof URL || filename.startsWith("file://")) {
+    return false;
+  }
+  if (filename.endsWith("/")) {
+    return true;
+  }
+  return !filename.split("/").pop().includes(".");
+}

--- a/lib/jiti-native.mjs
+++ b/lib/jiti-native.mjs
@@ -1,0 +1,77 @@
+import _createJiti from "../dist/jiti.cjs";
+
+/**
+ * @typedef {import('./types').Jiti} Jiti
+ * @typedef {import('./types').JitiOptions} JitiOptions
+ */
+
+/**
+ * @param {string} message
+ */
+function unsupportedError(message) {
+  throw new Error(
+    `[jiti] ${message} (import or require \`jiti/node\` for more features).`,
+  );
+}
+
+/**
+ * @param {string} parentURL
+ * @param {JitiOptions} opts
+ * @returns {Jiti}
+ */
+export function createJiti(parentURL, _opts) {
+  /** @type {Jiti} */
+  function jiti() {
+    throw unsupportedError(
+      "`jiti()` is not supported in native mode, use `jiti.import()` instead.",
+    );
+  }
+
+  jiti.resolve = () => {
+    throw unsupportedError("`jiti.resolve()` is not supported in native mode.");
+  };
+
+  jiti.esmResolve = (id, opts) => {
+    try {
+      return import.meta.resolve(id, opts?.parentURL || parentURL);
+    } catch (error) {
+      if (opts?.try) {
+        return undefined;
+      } else {
+        throw error;
+      }
+    }
+  };
+
+  jiti.import = async function (id, opts) {
+    const resolved = await this.esmResolve(id, opts);
+    if (!resolved) {
+      if (opts?.try) {
+        return undefined;
+      } else {
+        throw new Error(`Cannot resolve module '${id}'`);
+      }
+    }
+    return import(resolved);
+  };
+
+  jiti.transform = () => {
+    throw unsupportedError(
+      "`jiti.transform()` is not supported in native mode.",
+    );
+  };
+
+  jiti.evalModule = () => {
+    throw unsupportedError(
+      "`jiti.evalModule()` is not supported in native mode.",
+    );
+  };
+
+  jiti.main = undefined;
+  jiti.extensions = Object.create(null);
+  jiti.cache = Object.create(null);
+
+  return jiti;
+}
+
+export default createJiti;

--- a/lib/jiti-register-native.mjs
+++ b/lib/jiti-register-native.mjs
@@ -1,1 +1,0 @@
-// Nothing to register!

--- a/lib/jiti-register-native.mjs
+++ b/lib/jiti-register-native.mjs
@@ -1,0 +1,1 @@
+// Nothing to register!

--- a/package.json
+++ b/package.json
@@ -20,6 +20,21 @@
       "types": "./lib/jiti-register.d.mts",
       "import": "./lib/jiti-register.mjs"
     },
+    "./native": {
+      "bun": "./lib/jiti-native.mjs",
+      "deno": "./lib/jiti-native.mjs",
+      "node": {
+        "import": {
+          "types": "./lib/jiti.d.mts",
+          "default": "./lib/jiti.mjs"
+        },
+        "require": {
+          "types": "./lib/jiti.d.cts",
+          "default": "./lib/jiti.cjs"
+        }
+      },
+      "default": "./lib/jiti-native.mjs"
+    },
     "./package.json": "./package.json"
   },
   "main": "./lib/jiti.cjs",

--- a/test/bun-native.test.ts
+++ b/test/bun-native.test.ts
@@ -1,0 +1,26 @@
+import { fileURLToPath } from "node:url";
+import { readdir } from "node:fs/promises";
+// @ts-ignore
+import { test } from "bun:test";
+
+import { createJiti } from "../lib/jiti-native.mjs";
+
+const fixturesDir = fileURLToPath(new URL("fixtures", import.meta.url));
+
+const fixtures = await readdir(fixturesDir);
+
+const _jiti = createJiti(fixturesDir);
+
+for (const fixture of fixtures) {
+  if (
+    fixture === "error-runtime" ||
+    fixture === "error-parse" ||
+    fixture === "typescript"
+  ) {
+    continue;
+  }
+
+  test("fixtures/" + fixture + " (ESM) (Native)", async () => {
+    await _jiti.import("./" + fixture);
+  });
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
     exclude: [
       "**/test.{ts,mjs,cjs,js}",
       "node_modules/**/*",
-      "test/bun.test.ts",
+      "test/bun*.test.ts",
     ],
   },
 });


### PR DESCRIPTION
this adds a new `jiti/native` subpath export that for deno/bun/[unknown] export conditions except `node`, uses a passthrough implementation. it can be mainly useful for when we mainly require a functional `jiti.import` for typescript files without specific options.