### PR TITLE
refactor: always use native impl for `jiti/native`

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,19 +21,8 @@
       "import": "./lib/jiti-register.mjs"
     },
     "./native": {
-      "bun": "./lib/jiti-native.mjs",
-      "deno": "./lib/jiti-native.mjs",
-      "node": {
-        "import": {
-          "types": "./lib/jiti.d.mts",
-          "default": "./lib/jiti.mjs"
-        },
-        "require": {
-          "types": "./lib/jiti.d.cts",
-          "default": "./lib/jiti.cjs"
-        }
-      },
-      "default": "./lib/jiti-native.mjs"
+      "types": "./lib/jiti.d.mts",
+      "import": "./lib/jiti-native.mjs"
     },
     "./package.json": "./package.json"
   },


### PR DESCRIPTION
Updating #289 

This PR always uses ESM import syntax for `jiti/native` (also for `node` condition) for a consistent behavior. This way we can safely use it as an **alias** for compatibility.