### PR TITLE
refactor: rename `experimentalBun` to `tryNative`

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,13 +203,13 @@ List of modules (within `node_modules`) to transform them regardless of syntax.
 
 Parent module's [`import.meta`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import.meta) context to use for ESM resolution. (only used for `jiti/native` import).
 
-### `experimentalBun`
+### `tryNative`
 
 - Type: Boolean
-- Default: Enabled if `process.versions.bun` exists (Bun runtime)
-- Environment variable: `JITI_EXPERIMENTAL_BUN`
+- Default: Enabled if bun is detected
+- Environment variable: `JITI_TRY_NATIVE`
 
-Enable experimental native Bun support for transformations.
+Try to use native require and import without jiti transformations first.
 
 ## Development
 

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -139,9 +139,11 @@ export interface JitiOptions {
   importMeta?: ImportMeta;
 
   /**
-   * Enable experimental native Bun support for transformations.
+   * Try to use native require and import without jiti transformations first.
+   *
+   * Enabled if Bun is detected.
    */
-  experimentalBun?: boolean;
+  tryNative?: boolean;
 }
 
 export type ModuleCache = Record<string, NodeModule>;

--- a/src/options.ts
+++ b/src/options.ts
@@ -22,10 +22,7 @@ export function resolveJitiOptions(userOptions: JitiOptions): JitiOptions {
     alias: _jsonEnv<Record<string, string>>("JITI_ALIAS", {}),
     nativeModules: _jsonEnv<string[]>("JITI_NATIVE_MODULES", []),
     transformModules: _jsonEnv<string[]>("JITI_TRANSFORM_MODULES", []),
-    experimentalBun: _jsonEnv<boolean>(
-      "JITI_EXPERIMENTAL_BUN",
-      !!process.versions.bun,
-    ),
+    tryNative: _jsonEnv<boolean>("JITI_TRY_NATIVE", "Bun" in globalThis),
   };
 
   const deprecatOverrides: JitiOptions = {};

--- a/src/require.ts
+++ b/src/require.ts
@@ -28,7 +28,7 @@ export function jitiRequire(
   }
 
   // Experimental Bun support
-  if (ctx.opts.experimentalBun && !ctx.opts.transformOptions) {
+  if (ctx.opts.tryNative && !ctx.opts.transformOptions) {
     try {
       id = jitiResolve(ctx, id, opts);
       if (!id && opts.try) {
@@ -36,8 +36,7 @@ export function jitiRequire(
       }
       debug(
         ctx,
-        "[bun]",
-        "[native]",
+        "[try-native]",
         opts.async && ctx.nativeImport ? "[import]" : "[require]",
         id,
       );
@@ -56,7 +55,11 @@ export function jitiRequire(
         return jitiInteropDefault(ctx, _mod);
       }
     } catch (error: any) {
-      debug(ctx, `[bun] Using fallback for ${id} because of an error:`, error);
+      debug(
+        ctx,
+        `[try-native] Using fallback for ${id} because of an error:`,
+        error,
+      );
     }
   }
 


### PR DESCRIPTION
This PR renames `experimentalBun` option to `tryNative`. I tried to test it against Deno but the lastest 1.46.3 still has issues with CJS support. 

Users of jiti can opt-in to try-native with this new agnostic option.