### PR TITLE
fix: handle global url instance mismatch

### DIFF
--- a/lib/jiti-native.mjs
+++ b/lib/jiti-native.mjs
@@ -111,7 +111,7 @@ function normalizeParentURL(input) {
   if (!input) {
     return "file:///";
   }
-  if (typeof filename !== 'string' || input.startsWith("file://")) {
+  if (typeof filename !== "string" || input.startsWith("file://")) {
     return input;
   }
   if (input.endsWith("/")) {

--- a/lib/jiti-native.mjs
+++ b/lib/jiti-native.mjs
@@ -111,7 +111,7 @@ function normalizeParentURL(input) {
   if (!input) {
     return "file:///";
   }
-  if (input instanceof URL || input.startsWith("file://")) {
+  if (typeof filename !== 'string' || input.startsWith("file://")) {
     return input;
   }
   if (input.endsWith("/")) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,7 +8,7 @@ import type { Context } from "./types";
 import { gray, green, blue, yellow, cyan, red } from "yoctocolors";
 
 export function isDir(filename: string | URL): boolean {
-  if (filename instanceof URL || filename.startsWith("file://")) {
+  if (typeof filename !== 'string' || filename.startsWith("file://")) {
     return false;
   }
   try {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,7 +8,7 @@ import type { Context } from "./types";
 import { gray, green, blue, yellow, cyan, red } from "yoctocolors";
 
 export function isDir(filename: string | URL): boolean {
-  if (typeof filename !== 'string' || filename.startsWith("file://")) {
+  if (typeof filename !== "string" || filename.startsWith("file://")) {
     return false;
   }
   try {


### PR DESCRIPTION
When testing, it's possible that the `instanceof URL` test does not succeed. 

Discovered/reproducible via https://github.com/nuxt/ecosystem-ci/actions/runs/10953460888/job/30413781016.

I will see if I can create a minimal reproduction - there are several layers of nesting in the more complex reproduction, but raising in case this seems good to you (and I can confirm it does resolve the issue) or you have an idea where to look further.