### PR TITLE
feat: handle `data:` imports (non-native only)

### DIFF
--- a/src/require.ts
+++ b/src/require.ts
@@ -23,7 +23,7 @@ export function jitiRequire(
   } else if (id.startsWith("data:")) {
     if (opts.async === false) {
       throw new Error(
-        "data: URLs are not supported by CJS. Use import/jiti.import instead.",
+        "\`data:\` URLs are only supported in ESM context. Use `import` or `jiti.import` instead.",
       );
     } else {
       debug(ctx, "[native]", "[data]", "[import]", id);

--- a/src/require.ts
+++ b/src/require.ts
@@ -21,7 +21,7 @@ export function jitiRequire(
   } else if (id.startsWith("file:")) {
     id = fileURLToPath(id);
   } else if (id.startsWith("data:")) {
-    if (opts.async === false) {
+    if (!opts.async) {
       throw new Error(
         "\`data:\` URLs are only supported in ESM context. Use `import` or `jiti.import` instead.",
       );

--- a/src/require.ts
+++ b/src/require.ts
@@ -15,11 +15,14 @@ export function jitiRequire(
 ) {
   const cache = ctx.parentCache || {};
 
-  // Check for node: and file: protocol
+  // Check for node:, file:, and data: protocols
   if (id.startsWith("node:")) {
     id = id.slice(5);
   } else if (id.startsWith("file:")) {
     id = fileURLToPath(id);
+  } else if (id.startsWith("data:")) {
+    debug(ctx, "[native]", "[data]", opts.async ? "[import]" : "[require]", id);
+    return nativeImportOrRequire(ctx, id, opts.async);
   }
 
   // Check for builtin node module like fs

--- a/src/require.ts
+++ b/src/require.ts
@@ -23,7 +23,7 @@ export function jitiRequire(
   } else if (id.startsWith("data:")) {
     if (!opts.async) {
       throw new Error(
-        "\`data:\` URLs are only supported in ESM context. Use `import` or `jiti.import` instead.",
+        "`data:` URLs are only supported in ESM context. Use `import` or `jiti.import` instead.",
       );
     }
     debug(ctx, "[native]", "[data]", "[import]", id);

--- a/src/require.ts
+++ b/src/require.ts
@@ -21,8 +21,14 @@ export function jitiRequire(
   } else if (id.startsWith("file:")) {
     id = fileURLToPath(id);
   } else if (id.startsWith("data:")) {
-    debug(ctx, "[native]", "[data]", opts.async ? "[import]" : "[require]", id);
-    return nativeImportOrRequire(ctx, id, opts.async);
+    if (opts.async === false) {
+      throw new Error(
+        "data: URLs are not supported by CJS. Use import/jiti.import instead.",
+      );
+    } else {
+      debug(ctx, "[native]", "[data]", "[import]", id);
+      return nativeImportOrRequire(ctx, id, true);
+    }
   }
 
   // Check for builtin node module like fs

--- a/src/require.ts
+++ b/src/require.ts
@@ -25,10 +25,9 @@ export function jitiRequire(
       throw new Error(
         "\`data:\` URLs are only supported in ESM context. Use `import` or `jiti.import` instead.",
       );
-    } else {
-      debug(ctx, "[native]", "[data]", "[import]", id);
-      return nativeImportOrRequire(ctx, id, true);
     }
+    debug(ctx, "[native]", "[data]", "[import]", id);
+    return nativeImportOrRequire(ctx, id, true);
   }
 
   // Check for builtin node module like fs

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -72,6 +72,7 @@ const debugMap = {
   "[hit]": green("[hit]"),
   "[miss]": yellow("[miss]"),
   "[json]": green("[json]"),
+  "[data]": green("[data]"),
 };
 
 export function debug(ctx: Context, ...args: unknown[]) {

--- a/test/bun.test.ts
+++ b/test/bun.test.ts
@@ -21,7 +21,8 @@ for (const fixture of fixtures) {
   if (
     fixture === "error-runtime" ||
     fixture === "error-parse" ||
-    fixture === "typescript"
+    fixture === "typescript" ||
+    fixture === "data-uri"
   ) {
     continue;
   }

--- a/test/fixtures/data-uri/index.ts
+++ b/test/fixtures/data-uri/index.ts
@@ -1,0 +1,3 @@
+const script = `export default {a: "A"}`;
+const uri = "data:text/javascript;charset=utf-8," + encodeURIComponent(script);
+import(uri);

--- a/test/fixtures/data-uri/index.ts
+++ b/test/fixtures/data-uri/index.ts
@@ -1,3 +1,14 @@
+import assert from "node:assert";
+
 const script = `export default {a: "A"}`;
 const uri = "data:text/javascript;charset=utf-8," + encodeURIComponent(script);
+try {
+  require(uri);
+  throw null;
+} catch (error) {
+  assert(
+    error instanceof Error,
+    "Expected an error message for sync import of data URL",
+  );
+}
 import(uri);

--- a/test/fixtures/data-uri/index.ts
+++ b/test/fixtures/data-uri/index.ts
@@ -11,4 +11,4 @@ try {
     "Expected an error message for sync import of data URL",
   );
 }
-import(uri);
+await import(uri);

--- a/test/native/bun.test.ts
+++ b/test/native/bun.test.ts
@@ -8,7 +8,12 @@ const fixtures = await readdir(new URL("../fixtures", import.meta.url));
 
 const jiti = createJiti(import.meta.url, { importMeta: import.meta });
 
-const ignore = new Set(["error-runtime", "error-parse", "typescript"]);
+const ignore = new Set([
+  "error-runtime",
+  "error-parse",
+  "typescript",
+  "data-uri",
+]);
 
 for (const fixture of fixtures) {
   if (ignore.has(fixture)) {

--- a/test/native/deno.test.ts
+++ b/test/native/deno.test.ts
@@ -21,6 +21,7 @@ const ignore = new Set(
     "top-level-await",
     "exotic",
     "circular",
+    "data-uri",
     "import-map",
   ].filter(Boolean),
 );

--- a/test/native/node.test.ts
+++ b/test/native/node.test.ts
@@ -21,6 +21,7 @@ const ignore = new Set(
     "top-level-await",
     "exotic",
     "circular",
+    "data-uri",
   ].filter(Boolean),
 );
 


### PR DESCRIPTION
Resolves https://github.com/unjs/jiti/issues/207

Explicitly check for `data:` scheme and use native import to handle it.