### PR TITLE
feat: eval esm modules with  fallback loader

### DIFF
--- a/test/__snapshots__/fixtures.test.ts.snap
+++ b/test/__snapshots__/fixtures.test.ts.snap
@@ -51,6 +51,8 @@ exports[`fixtures > hashbang > stdout 1`] = `"1"`;
 
 exports[`fixtures > import-map > stdout 1`] = `"{ alias: 'alias' }"`;
 
+exports[`fixtures > import-meta > stdout 1`] = `"hello! { hello: 'world' }"`;
+
 exports[`fixtures > json > stdout 1`] = `
 "Imported : { test: 123 } .default: { test: 123 }
 Imported with assertion : { test: 123 } .default: { test: 123 }

--- a/test/fixtures/import-meta/index.ts
+++ b/test/fixtures/import-meta/index.ts
@@ -1,2 +1,10 @@
+declare global {
+  interface ImportMeta {
+    custom: any;
+  }
+}
+
 import.meta.custom = { hello: "world" };
 console.log("hello!", import.meta.custom);
+
+export {};

--- a/test/fixtures/import-meta/index.ts
+++ b/test/fixtures/import-meta/index.ts
@@ -1,0 +1,2 @@
+import.meta.custom = { hello: "world" };
+console.log("hello!", import.meta.custom);

--- a/test/fixtures/import-meta/package.json
+++ b/test/fixtures/import-meta/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}


### PR DESCRIPTION
Resolves #167

In the async context (`jiti.import`), we can use an alternative ESM loader using dynamic imports which is slower but increases compatibility.

(Alternatively we could directly import from cache result but it needs edge-case handling for when case is disabled and HMR support will be lost too)