### PR TITLE
refactor: make `jiti.esmResolve` consistent with `import.meta.resolve`

### DIFF
--- a/lib/jiti-hooks.mjs
+++ b/lib/jiti-hooks.mjs
@@ -1,5 +1,5 @@
 import { dirname, join } from "node:path";
-import { fileURLToPath, pathToFileURL } from "node:url";
+import { fileURLToPath } from "node:url";
 import { existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { isBuiltin } from "node:module";
@@ -22,7 +22,7 @@ export async function resolve(specifier, context, nextResolve) {
     conditions: context?.conditions,
   });
   return {
-    url: pathToFileURL(resolvedPath).href,
+    url: resolvedPath,
     shortCircuit: true,
   };
 }

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -21,6 +21,7 @@ export interface Jiti extends NodeRequire {
   /**
    * Resolve with ESM import conditions.
    */
+  esmResolve(id: string, parentURL?: string): string;
   esmResolve<T extends JitiResolveOptions = JitiResolveOptions>(
     id: string,
     opts?: T,

--- a/src/eval.ts
+++ b/src/eval.ts
@@ -1,7 +1,6 @@
 import { Module } from "node:module";
 import { performance } from "node:perf_hooks";
 import vm from "node:vm";
-import { pathToFileURL } from "node:url";
 import { dirname, basename, extname } from "pathe";
 import { hasESMSyntax } from "mlly";
 import {
@@ -10,12 +9,7 @@ import {
   readNearestPackageJSON,
   wrapModule,
 } from "./utils";
-import type {
-  ModuleCache,
-  Context,
-  EvalModuleOptions,
-  JitiResolveOptions,
-} from "./types";
+import type { ModuleCache, Context, EvalModuleOptions } from "./types";
 import { jitiResolve } from "./resolve";
 import { jitiRequire, nativeImportOrRequire } from "./require";
 import createJiti from "./jiti";
@@ -151,18 +145,6 @@ export function evalModule(
     }
   }
 
-  // import.meta.resolve polyfill
-  // TODO: Make esmResolve more consistent with this
-  const importMetaResolve = (id: string, opts?: string | JitiResolveOptions) =>
-    pathToFileURL(
-      _jiti.esmResolve(
-        id,
-        typeof opts === "string"
-          ? { parentURL: opts }
-          : { parentURL: mod.filename, ...opts },
-      ),
-    ).href;
-
   // Evaluate module
   let evalResult;
   try {
@@ -173,7 +155,7 @@ export function evalModule(
       mod.filename,
       dirname(mod.filename),
       _jiti.import,
-      importMetaResolve,
+      _jiti.esmResolve,
     );
   } catch (error: any) {
     if (ctx.opts.moduleCache) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,7 +11,7 @@ export type {
 
 export interface Context {
   filename: string;
-  url: URL;
+  url: string;
   parentModule?: NodeModule;
   parentCache?: ModuleCache;
   nativeImport?: (id: string) => Promise<any>;


### PR DESCRIPTION
Make new `jiti.esmResolve` consistent with `import.meta.resolvd`

- The second argument can be also a string (parentURL same as node.js-behind-the-flag feature)
- Return value is always `file://` string normalized with mlly.
