### PR TITLE
build: fix `/register` and `/native` subpath types for `Node10` module resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,16 @@
   "main": "./lib/jiti.cjs",
   "module": "./lib/jiti.mjs",
   "types": "./lib/jiti.d.cts",
+  "typesVersions": {
+    "*": {
+      "register": [
+        "./lib/jiti-register.d.mts"
+      ],
+      "native": [
+        "./lib/jiti.d.mts"
+      ]
+    }
+  },
   "bin": {
     "jiti": "./lib/jiti-cli.mjs"
   },


### PR DESCRIPTION
## **This PR**:

- [X] Fixes the type definitions for TypeScript's `Node10` module resolution.

<details><summary><h4><b>Before</b></h4></summary>

![jiti-before](https://github.com/user-attachments/assets/2b3f728a-4f06-46b8-bc58-a4c037f17b3a)

</details>

<details><summary><h4><b>After</b></h4></summary>

![jiti-after](https://github.com/user-attachments/assets/ed652bb0-e84e-4e6a-bb44-272caa8e99ff)

</deatils>