### PR TITLE
fix: make `TransformOptions` type strict to allow auto-complete 

### DIFF
--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -177,9 +177,9 @@ export interface TransformOptions {
   ts?: boolean;
   retainLines?: boolean;
   interopDefault?: boolean;
-  async: boolean;
+  async?: boolean;
   jsx?: boolean | JSXOptions;
-  [key: string]: any;
+  babel?: Record<string, any>;
 }
 
 export interface TransformResult {


### PR DESCRIPTION
## **This PR**:

- [X] Fixes the `TransformOptions` type to not sacrifice auto-completion.