### PR TITLE
chore: update relative imports

### DIFF
--- a/src/plugins/transform-module/lazy.ts
+++ b/src/plugins/transform-module/lazy.ts
@@ -3,7 +3,7 @@
 // https://github.com/babel/babel/tree/c7bb6e0f/packages/babel-plugin-transform-modules-commonjs/src
 import { template, types as t } from "@babel/core";
 import { isSideEffectImport } from "@babel/helper-module-transforms";
-import type { CommonJSHook } from "./hooks.ts";
+import type { CommonJSHook } from "./hooks.js";
 
 type Lazy = boolean | string[] | ((source: string) => boolean);
 


### PR DESCRIPTION
## **This PR**:

- [X] Change the import path extension in `src/plugins/transform-module/lazy.ts` from `.ts` to `.js`.

Also not sure why `tsc` didn't catch this, I think it should since we don't have `allowImportingTsExtensions` turned on.