### PR TITLE
feat: enable `interopDefault` by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Or:
 node --import jiti/register index.ts
 ```
 
-## 🎈 `jiti/native` 
+## 🎈 `jiti/native`
 
 You can alias `jiti` to `jiti/native` to directly depend on runtime's [`import.meta.resolve`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import.meta/resolve) and dynamic [`import()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import) support. This allows easing up the ecosystem transition to runtime native support by giving the same API of jiti.
 
@@ -148,10 +148,12 @@ Add inline source map to transformed source for better debugging.
 ### `interopDefault`
 
 - Type: Boolean
-- Default: `false`
+- Default: `true`
 - Environment variable: `JITI_INTEROP_DEFAULT`
 
-Return the `.default` export of a module at the top level.
+Return the default export of a module at the top-level, alongside any other named exports.
+
+See [`mlly.interopDefault`](https://github.com/unjs/mlly#interopdefault) and the [implementation](https://github.com/unjs/mlly/blob/2348417d25522b98ed60ccc10eb030abb2f65744/src/cjs.ts#L59) for more info.
 
 ### `alias`
 

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Add inline source map to transformed source for better debugging.
 - Default: `true`
 - Environment variable: `JITI_INTEROP_DEFAULT`
 
-Return the default export of a module at the top-level, alongside any other named exports.
+Uses the default export of a modules (if exists), alongside any other named exports combined.
 
 See [`mlly.interopDefault`](https://github.com/unjs/mlly#interopdefault) and the [implementation](https://github.com/unjs/mlly/blob/2348417d25522b98ed60ccc10eb030abb2f65744/src/cjs.ts#L59) for more info.
 

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Add inline source map to transformed source for better debugging.
 - Default: `true`
 - Environment variable: `JITI_INTEROP_DEFAULT`
 
-Uses the default export of a modules (if exists), alongside any other named exports combined.
+Uses the default export of modules (if exists), alongside any other named exports combined.
 
 See [`mlly.interopDefault`](https://github.com/unjs/mlly#interopdefault) and the [implementation](https://github.com/unjs/mlly/blob/2348417d25522b98ed60ccc10eb030abb2f65744/src/cjs.ts#L59) for more info.
 

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -92,9 +92,9 @@ export interface JitiOptions {
   sourceMaps?: boolean;
 
   /**
-   * Interop default export (disabled by default)
+   * Interop default export (enabled by default)
    *
-   * Can be enabled using `JITI_INTEROP_DEFAULT=1` environment variable.
+   * Can be disabled using `JITI_INTEROP_DEFAULT=0` environment variable.
    */
   interopDefault?: boolean;
 

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -92,7 +92,7 @@ export interface JitiOptions {
   sourceMaps?: boolean;
 
   /**
-   * Interop default export (enabled by default)
+   * Uses the default export of a modules (if exists), alongside any other named exports combined.
    *
    * Can be disabled using `JITI_INTEROP_DEFAULT=0` environment variable.
    */

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -92,7 +92,7 @@ export interface JitiOptions {
   sourceMaps?: boolean;
 
   /**
-   * Uses the default export of a modules (if exists), alongside any other named exports combined.
+   * Uses the default export of modules (if exists), alongside any other named exports combined.
    *
    * Can be disabled using `JITI_INTEROP_DEFAULT=0` environment variable.
    */

--- a/src/options.ts
+++ b/src/options.ts
@@ -9,7 +9,7 @@ export function resolveJitiOptions(userOptions: JitiOptions): JitiOptions {
     ),
     debug: _booleanEnv("JITI_DEBUG", false),
     sourceMaps: _booleanEnv("JITI_SOURCE_MAPS", false),
-    interopDefault: _booleanEnv("JITI_INTEROP_DEFAULT", !false),
+    interopDefault: _booleanEnv("JITI_INTEROP_DEFAULT", true),
     extensions: _jsonEnv<string[]>("JITI_EXTENSIONS", [
       ".js",
       ".mjs",

--- a/src/options.ts
+++ b/src/options.ts
@@ -9,7 +9,7 @@ export function resolveJitiOptions(userOptions: JitiOptions): JitiOptions {
     ),
     debug: _booleanEnv("JITI_DEBUG", false),
     sourceMaps: _booleanEnv("JITI_SOURCE_MAPS", false),
-    interopDefault: _booleanEnv("JITI_INTEROP_DEFAULT", false),
+    interopDefault: _booleanEnv("JITI_INTEROP_DEFAULT", !false),
     extensions: _jsonEnv<string[]>("JITI_EXTENSIONS", [
       ".js",
       ".mjs",

--- a/test/__snapshots__/fixtures.test.ts.snap
+++ b/test/__snapshots__/fixtures.test.ts.snap
@@ -27,8 +27,8 @@ exports[`fixtures > error-runtime > stderr 1`] = `"test error"`;
 exports[`fixtures > error-runtime > stdout 1`] = `""`;
 
 exports[`fixtures > esm > stdout 1`] = `
-"{ utilsLib: { utils: { a: 'a', default: 'default' }, version: '123' } }
-{ utils: { a: 'a', default: 'default' } }
+"{ utilsLib: { utils: { default: 'default' }, version: '123' } }
+{ utils: { default: 'default' } }
 {
   file: '<cwd>/test.js',
   dir: '<cwd>',
@@ -62,7 +62,7 @@ exports[`fixtures > json > stdout 1`] = `
 "Imported : { test: 123 } .default: { test: 123 }
 Imported with assertion : { test: 123 } .default: { test: 123 }
 Required : { test: 123 } .default: { test: 123 }
-Dynamic Imported : { test: 123 } .default: { test: 123 }"
+Dynamic Imported : [Object: null prototype] { test: 123, default: { test: 123 } } .default: { test: 123 }"
 `;
 
 exports[`fixtures > jsx > stdout 1`] = `


### PR DESCRIPTION
Today most of the cases of jiti require `interopDefault` for mixed compatibility with native ESM, npm package and also between (babel) transformed modules of jiti.

Early testing seems it be a safe (although there might be edge-cases) change and also jiti v2 has not widely-adopted yet.