### PR TITLE
perf(cli): enable node 22 compile cache

### DIFF
--- a/lib/jiti-cli.mjs
+++ b/lib/jiti-cli.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { resolve } from "node:path";
-import { createJiti } from "./jiti.cjs";
+import nodeModule from "node:module";
 
 const script = process.argv.splice(2, 1)[0];
 
@@ -10,8 +10,26 @@ if (!script) {
   process.exit(1);
 }
 
+// https://nodejs.org/api/module.html#moduleenablecompilecachecachedir
+// https://github.com/nodejs/node/pull/54501
+if (nodeModule.enableCompileCache && !process.env.NODE_DISABLE_COMPILE_CACHE) {
+  try {
+    nodeModule.enableCompileCache();
+  } catch {
+    // Ignore errors
+  }
+}
+
 const pwd = process.cwd();
+
+const { createJiti } = nodeModule.createRequire(import.meta.url)("./jiti.cjs");
+// const { createJiti } = await import("./jiti.cjs");
+
 const jiti = createJiti(pwd);
+
 const resolved = (process.argv[1] = jiti.resolve(resolve(pwd, script)));
 
-jiti.import(resolved).catch(console.error);
+await jiti.import(resolved).catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/lib/jiti-cli.mjs
+++ b/lib/jiti-cli.mjs
@@ -22,8 +22,7 @@ if (nodeModule.enableCompileCache && !process.env.NODE_DISABLE_COMPILE_CACHE) {
 
 const pwd = process.cwd();
 
-const { createJiti } = nodeModule.createRequire(import.meta.url)("./jiti.cjs");
-// const { createJiti } = await import("./jiti.cjs");
+const { createJiti } = await import("./jiti.cjs");
 
 const jiti = createJiti(pwd);
 

--- a/test/__snapshots__/fixtures.test.ts.snap
+++ b/test/__snapshots__/fixtures.test.ts.snap
@@ -37,7 +37,8 @@ exports[`fixtures > esm > stdout 1`] = `
     'at getStack (<cwd>/test)',
     'at test (<cwd>/test)',
     'at async <cwd>/index.js',
-    'at async Function.import (<root>/dist/jiti.cjs)'
+    'at async Function.import (<root>/dist/jiti.cjs)',
+    'at async file://<root>/lib/jiti-cli.mjs'
   ]
 }"
 `;


### PR DESCRIPTION
Leverage new `module.enableCompileCache` for Node.js 22+ (more info https://github.com/nodejs/node/pull/54501)

Speedup is about %17 in Node.js v22.9.0 (Intel(R) Core(TM) i7-10700K CPU @ 3.80GHz perf mode)

```
hyperfine --warmup 3 'node ./lib/jiti-cli.mjs test/fixtures/typescript' 'NODE_DISABLE_COMPILE_CACHE=1 node ./lib/jiti-cli.mjs test/fixtures/typescript'
```

```
Benchmark 1: node ./lib/jiti-cli.mjs test/fixtures/typescript
  Time (mean ± σ):     130.3 ms ±   0.8 ms    [User: 131.3 ms, System: 18.0 ms]
  Range (min … max):   128.8 ms … 131.3 ms    22 runs
 
Benchmark 2: NODE_DISABLE_COMPILE_CACHE=1 node ./lib/jiti-cli.mjs test/fixtures/typescript
  Time (mean ± σ):     152.0 ms ±   1.1 ms    [User: 149.2 ms, System: 22.0 ms]
  Range (min … max):   150.1 ms … 154.0 ms    19 runs
 
Summary
  'node ./lib/jiti-cli.mjs test/fixtures/typescript' ran
    1.17 ± 0.01 times faster than 'NODE_DISABLE_COMPILE_CACHE=1 node ./lib/jiti-cli.mjs test/fixtures/typescript'
```

