### PR TITLE
refactor: deprecate commonjs api

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@
 
 - Seamless Typescript and ESM syntax support for Node.js
 - Seamless interoperability between ESM and CommonJS
-- Synchronous API to replace `require()`
 - Asynchronous API to replace `import()`
+- Synchronous API to replace `require()` (deprecated)
 - Super slim and zero dependency
 - Custom resolve aliases
 - Smart syntax detection to avoid extra transforms
@@ -47,7 +47,7 @@ Initialize a jiti instance:
 import { createJiti } from "jiti";
 const jiti = createJiti(import.meta.url);
 
-// CommonJS
+// CommonJS (deprecated)
 const { createJiti } = require("jiti");
 const jiti = createJiti(__filename);
 ```
@@ -62,7 +62,7 @@ await jiti.import("./path/to/file.ts");
 const resolvedPath = jiti.esmResolve("./src");
 ```
 
-CommonJS (sync - legacy):
+CommonJS (sync & deprecated):
 
 ```js
 // jiti() acts like require() with Typescript and (non async) ESM support

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -7,7 +7,21 @@ export declare function createJiti(id: string, userOptions?: JitiOptions): Jiti;
  *
  * **Note:**It is recommended to use `await jiti.import` instead
  */
-export interface Jiti extends NodeRequire {
+export interface Jiti {
+  /** @deprecated Prefer `await jiti.import()` for better compatibility. */
+  (id: string): any;
+
+  /** @deprecated Prefer `jiti.esmResolve` for better compatibility. */
+  resolve: RequireResolve;
+
+  /** @deprecated */
+  extensions: RequireExtensions;
+
+  /** @deprecated CommonJS API */
+  main: Module | undefined;
+
+  cache: Dict<NodeModule>;
+
   /**
    * Resolved options
    */


### PR DESCRIPTION
Use `@deprecated` annotations to encourage migrating to ESM-compatible async API.