### PR TITLE
feat: use smarter proxy for `interopDefault`

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "changelogen": "^0.5.7",
     "config": "^3.3.12",
     "consola": "^3.2.3",
+    "defu": "^6.1.4",
     "destr": "^2.0.3",
     "escape-string-regexp": "^5.0.0",
     "eslint": "^9.11.1",

--- a/package.json
+++ b/package.json
@@ -125,7 +125,8 @@
     "webpack-bundle-analyzer": "^4.10.2",
     "webpack-cli": "^5.1.4",
     "webpack-license-plugin": "^4.5.0",
-    "yoctocolors": "^2.1.1"
+    "yoctocolors": "^2.1.1",
+    "zod": "^3.23.8"
   },
   "packageManager": "pnpm@9.11.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -188,6 +188,9 @@ importers:
       yoctocolors:
         specifier: ^2.1.1
         version: 2.1.1
+      zod:
+        specifier: ^3.23.8
+        version: 3.23.8
 
 packages:
 
@@ -2476,6 +2479,9 @@ packages:
   yoctocolors@2.1.1:
     resolution: {integrity: sha512-GQHQqAopRhwU8Kt1DDM8NjibDXHC8eoh1erhGAJPEyveY9qqVeXvVikNKrDz69sHowPMorbPUrH/mx8c50eiBQ==}
     engines: {node: '>=18'}
+
+  zod@3.23.8:
+    resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
 
 snapshots:
 
@@ -4827,3 +4833,5 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   yoctocolors@2.1.1: {}
+
+  zod@3.23.8: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,6 +92,9 @@ importers:
       consola:
         specifier: ^3.2.3
         version: 3.2.3
+      defu:
+        specifier: ^6.1.4
+        version: 6.1.4
       destr:
         specifier: ^2.0.3
         version: 2.0.3

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -111,7 +111,11 @@ function interopDefault(
     return sourceModule;
   }
   const defaultValue = sourceModule.default;
-  if (defaultValue === undefined || defaultValue === null) {
+  if (
+    defaultValue === undefined ||
+    defaultValue === null ||
+    !Object.isExtensible(defaultValue)
+  ) {
     return sourceModule;
   }
   const _defaultType = typeof defaultValue;
@@ -132,8 +136,8 @@ function interopDefault(
           },
         });
       }
-    } catch {
-      // Ignore error
+    } catch (error_) {
+      console.log(error_);
     }
   }
   return defaultValue;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -125,15 +125,15 @@ function interopDefault(mod: any): any {
   return new Proxy(mod, {
     get(target, prop, receiver) {
       if (prop === "__esModule") {
-        return true; // Bypass other interops
+        return true;
+      }
+      if (prop === "default") {
+        return defaultExport;
       }
       if (Reflect.has(target, prop)) {
         return Reflect.get(target, prop, receiver);
       }
-      let fallback =
-        prop === "default"
-          ? defaultExport
-          : Reflect.get(defaultExport, prop, receiver);
+      let fallback = Reflect.get(defaultExport, prop, receiver);
       if (typeof fallback === "function") {
         fallback = fallback.bind(defaultExport);
       }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -112,14 +112,14 @@ function interopDefault(mod: any): any {
     return mod;
   }
 
+  const modKeys = Object.getOwnPropertyNames(mod);
+  if (modKeys.length === 1 || (modKeys.length === 2 && "__esModule" in mod)) {
+    return defaultExport;
+  }
+
   const defaultExportType = typeof defaultExport;
   if (defaultExportType !== "object" && defaultExportType !== "function") {
     return mod;
-  }
-
-  const modKeys = Object.getOwnPropertyNames(mod);
-  if (modKeys.length === 1) {
-    return defaultExport;
   }
 
   return new Proxy(mod, {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -102,45 +102,52 @@ export function jitiInteropDefault(ctx: Context, mod: any) {
   return ctx.opts.interopDefault ? interopDefault(mod) : mod;
 }
 
-// Source: https://github.com/unjs/mlly/blob/2348417d25522b98ed60ccc10eb030abb2f65744/src/cjs.ts#L59C1-L93C2
-function interopDefault(
-  sourceModule: any,
-  opts: { preferNamespace?: boolean } = {},
-): any {
-  if (!isObject(sourceModule) || !("default" in sourceModule)) {
-    return sourceModule;
+function interopDefault(mod: any): any {
+  if (!mod || !("default" in mod)) {
+    return mod;
   }
-  const defaultValue = sourceModule.default;
-  if (
-    defaultValue === undefined ||
-    defaultValue === null ||
-    !Object.isExtensible(defaultValue)
-  ) {
-    return sourceModule;
+
+  const defaultExport = mod.default;
+  if (defaultExport === undefined || defaultExport === null) {
+    return mod;
   }
-  const _defaultType = typeof defaultValue;
-  if (
-    _defaultType !== "object" &&
-    !(_defaultType === "function" && !opts.preferNamespace)
-  ) {
-    return opts.preferNamespace ? sourceModule : defaultValue;
+
+  const defaultExportType = typeof defaultExport;
+  if (defaultExportType !== "object" && defaultExportType !== "function") {
+    return mod;
   }
-  for (const key in sourceModule) {
-    try {
-      if (!(key in defaultValue)) {
-        Object.defineProperty(defaultValue, key, {
-          enumerable: key !== "default",
-          configurable: key !== "default",
-          get() {
-            return sourceModule[key];
-          },
-        });
+
+  const modKeys = Object.getOwnPropertyNames(mod);
+  if (modKeys.length === 1) {
+    return defaultExport;
+  }
+
+  return new Proxy(mod, {
+    get(target, prop, receiver) {
+      if (prop === "__esModule") {
+        return true; // Bypass other interops
       }
-    } catch (error_) {
-      console.log(error_);
-    }
-  }
-  return defaultValue;
+      if (Reflect.has(target, prop)) {
+        return Reflect.get(target, prop, receiver);
+      }
+      let fallback =
+        prop === "default"
+          ? defaultExport
+          : Reflect.get(defaultExport, prop, receiver);
+      if (typeof fallback === "function") {
+        fallback = fallback.bind(defaultExport);
+      }
+      return fallback;
+    },
+    apply(target, thisArg, args) {
+      if (typeof target === "function") {
+        return Reflect.apply(target, thisArg, args);
+      }
+      if (defaultExportType === "function") {
+        return Reflect.apply(defaultExport, thisArg, args);
+      }
+    },
+  });
 }
 
 export function normalizeWindowsImportId(id: string) {

--- a/test/__snapshots__/fixtures.test.ts.snap
+++ b/test/__snapshots__/fixtures.test.ts.snap
@@ -8,10 +8,13 @@ exports[`fixtures > data-uri > stdout 1`] = `""`;
 
 exports[`fixtures > deps > stdout 1`] = `
 "npm:config: true
+npm:defu {}
+npm:destr true
 npm:etag: true
 npm:mime: true
 npm:typescript: true
-npm:moment-timezone true"
+npm:moment-timezone true
+npm:zod: true"
 `;
 
 exports[`fixtures > env > stdout 1`] = `
@@ -35,8 +38,8 @@ exports[`fixtures > error-runtime > stderr 1`] = `"test error"`;
 exports[`fixtures > error-runtime > stdout 1`] = `""`;
 
 exports[`fixtures > esm > stdout 1`] = `
-"{ utilsLib: { utils: { default: 'default' }, version: '123' } }
-{ utils: { default: 'default' } }
+"{ utilsLib: { utils: { a: 'a', default: 'default' }, version: '123' } }
+{ utils: { a: 'a', default: 'default' } }
 {
   file: '<cwd>/test.js',
   dir: '<cwd>',

--- a/test/fixtures/deps/defu.ts
+++ b/test/fixtures/deps/defu.ts
@@ -1,0 +1,4 @@
+import defuDefault from "defu";
+import { defu } from "defu";
+
+console.log("npm:defu", defu({}) && defuDefault({}));

--- a/test/fixtures/deps/destr.ts
+++ b/test/fixtures/deps/destr.ts
@@ -1,0 +1,7 @@
+import { destr } from "destr";
+import destrDefault from "destr";
+
+console.log(
+  "npm:destr",
+  destr("true") === true && destrDefault("true") === true,
+);

--- a/test/fixtures/deps/index.ts
+++ b/test/fixtures/deps/index.ts
@@ -1,5 +1,7 @@
 import "./config";
 import "./consola";
+import "./defu";
+import "./destr";
 import "./etag";
 import "./mime";
 import "./typescript";

--- a/test/fixtures/deps/index.ts
+++ b/test/fixtures/deps/index.ts
@@ -4,3 +4,4 @@ import "./etag";
 import "./mime";
 import "./typescript";
 import "./moment";
+import "./zod";

--- a/test/fixtures/deps/zod.ts
+++ b/test/fixtures/deps/zod.ts
@@ -1,0 +1,4 @@
+// @ts-ignore
+import { z } from "zod";
+
+console.log("npm:zod:", z.string().parse("hello world") === "hello world");


### PR DESCRIPTION
Resolves #317

With jiti [v2.0.0](https://github.com/unjs/jiti/releases/tag/v2.0.0) we have introduced native ESM import support which added a new kind of mixed export handling syntax. Early testing showed jiti v2 is broken with packages like `mime` without `interop` in mixed cases so in [v2.1.0](https://github.com/unjs/jiti/releases/tag/v2.1.0) we have enabled `interopDefault` by default to support out of the box.

Issues like #317 indicate that dependencies like `zod` will now be broken (because zod's default export is not expandable)

This PR introduces a new kind of interopDefault using a Proxy which at least covers all of our current test fixtures and can be used to cover more of similar cases if reported in the future on proxy layer instead of modify default exports.