### PR TITLE
fix(interopDefault): avoid `in` operator for primitive inputs

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -103,7 +103,7 @@ export function jitiInteropDefault(ctx: Context, mod: any) {
 }
 
 function interopDefault(mod: any): any {
-  if (!mod || !("default" in mod)) {
+  if (!mod) {
     return mod;
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -103,7 +103,8 @@ export function jitiInteropDefault(ctx: Context, mod: any) {
 }
 
 function interopDefault(mod: any): any {
-  if (!mod) {
+  const modType = typeof mod;
+  if (mod === null || (modType !== "object" && modType !== "function")) {
     return mod;
   }
 


### PR DESCRIPTION
resolves #319 (regression of #318)

If module export is a primitive like a number of string, `in` operator can throw an error. 

Instead, we can simply make sure `mod` is an object or (extended) function. (null/undefined default is still checked in line after)  