### PR TITLE
refactor(interopDefault): simplify logic for default export checks

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -108,18 +108,9 @@ function interopDefault(mod: any): any {
     return mod;
   }
 
-  const defaultExport = mod.default;
-  if (defaultExport === undefined || defaultExport === null) {
-    return mod;
-  }
-
-  const modKeys = Object.getOwnPropertyNames(mod);
-  if (modKeys.length === 1 || (modKeys.length === 2 && "__esModule" in mod)) {
-    return defaultExport;
-  }
-
-  const defaultExportType = typeof defaultExport;
-  if (defaultExportType !== "object" && defaultExportType !== "function") {
+  const def = mod.default;
+  const defType = typeof def;
+  if (def === null || (defType !== "object" && defType !== "function")) {
     return mod;
   }
 
@@ -129,14 +120,14 @@ function interopDefault(mod: any): any {
         return true;
       }
       if (prop === "default") {
-        return defaultExport;
+        return def;
       }
       if (Reflect.has(target, prop)) {
         return Reflect.get(target, prop, receiver);
       }
-      let fallback = Reflect.get(defaultExport, prop, receiver);
+      let fallback = Reflect.get(def, prop, receiver);
       if (typeof fallback === "function") {
-        fallback = fallback.bind(defaultExport);
+        fallback = fallback.bind(def);
       }
       return fallback;
     },
@@ -144,8 +135,8 @@ function interopDefault(mod: any): any {
       if (typeof target === "function") {
         return Reflect.apply(target, thisArg, args);
       }
-      if (defaultExportType === "function") {
-        return Reflect.apply(defaultExport, thisArg, args);
+      if (defType === "function") {
+        return Reflect.apply(def, thisArg, args);
       }
     },
   });

--- a/test/bun.test.ts
+++ b/test/bun.test.ts
@@ -47,10 +47,10 @@ test("hmr", async () => {
   let value;
 
   await writeFile(tmpFile, "export default 1");
-  value = _jiti(tmpFile);
-  expect(value).toBe(1);
+  value = (await _jiti.import(tmpFile)) as any;
+  expect(value.default).toBe(1);
 
   await writeFile(tmpFile, "export default 2");
-  value = _jiti(tmpFile);
-  expect(value).toBe(2);
+  value = (await _jiti.import(tmpFile)) as any;
+  expect(value.default).toBe(2);
 });


### PR DESCRIPTION
Simplify `interopDefault` introduced in #318

Other than simplification, this PR causes to make use of Proxy in more cases (even if there is single `default` export) for better future compatibility.

> [!IMPORTANT]
> This is another behavior change in 2.x line to align behavior better with native `import`, if default export is a primitive, it needs to be accessed with `.default`.