### PR TITLE
feat: support `jiti.import(id, {default: true})`

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 - JSX support (opt-in)
 
 > [!IMPORTANT]
-> To enhance npm compatibility with the introduction of native ESM, jiti `>=2.1` enabled [`interopdefault`](https://github.com/unjs/jiti#interopdefault) using a new Proxy. This may cause behavior changes, especially if you migrated to `2.0.0` earlier.
+> To enhance npm compatibility with the introduction of native ESM, jiti `>=2.1` enabled [`interopdefault`](#interopdefault) using a new Proxy. This may cause behavior changes, especially if you migrated to `2.0.0` earlier.
 
 ## 💡 Usage
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 - JSX support (opt-in)
 
 > [!IMPORTANT]
-> To enhance npm compatibility with the introduction of native ESM, jiti `>=2.1` enabled [`interopdefault`](https://github.com/unjs/jiti#interopdefault) using a new Proxy. This may cause behavior changes, especially if you migrated to `2.0.0` earlier, you might need to explicitly use the `.default` value of `jiti()`/`jiti.import()`.
+> To enhance npm compatibility with the introduction of native ESM, jiti `>=2.1` enabled [`interopdefault`](https://github.com/unjs/jiti#interopdefault) using a new Proxy. This may cause behavior changes, especially if you migrated to `2.0.0` earlier.
 
 ## 💡 Usage
 

--- a/README.md
+++ b/README.md
@@ -55,20 +55,27 @@ const jiti = createJiti(__filename);
 Import (async) and resolve with ESM compatibility:
 
 ```js
-// jiti.import() acts like import() with TypeScript support
-await jiti.import("./path/to/file.ts");
+// jiti.import(id) is similar to import(id)
+const mod = await jiti.import("./path/to/file.ts");
 
-// jiti.esmResolve() acts like import.meta.resolve() with additional features
+// jiti.esmResolve(id) is similar to import.meta.resolve(id)
 const resolvedPath = jiti.esmResolve("./src");
+```
+
+If you need the default export of module, you can use `jiti.import(id, { default: true })` as shortcut to `mod.default ?? mod`.
+
+```js
+// shortcut to mod.default ?? mod
+const modDefault = await jiti.import("./path/to/file.ts", { default: true });
 ```
 
 CommonJS (sync & deprecated):
 
 ```js
-// jiti() acts like require() with TypeScript and (non async) ESM support
-jiti("./path/to/file.ts");
+// jiti() is similar to require(id)
+const mod = jiti("./path/to/file.ts");
 
-// jiti.resolve() acts like require.resolve() with additional features
+// jiti.resolve() is similar to require.resolve(id)
 const resolvedPath = jiti.resolve("./src");
 ```
 

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -15,6 +15,8 @@ export interface Jiti extends NodeRequire {
 
   /**
    * ESM import a module with additional Typescript and ESM compatibility.
+   *
+   * If you need the default export of module, you can use `jiti.import(id, { default: true })` as shortcut to `mod.default ?? mod`.
    */
   import(
     id: string,

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -16,7 +16,10 @@ export interface Jiti extends NodeRequire {
   /**
    * ESM import a module with additional Typescript and ESM compatibility.
    */
-  import(id: string, opts?: JitiResolveOptions): Promise<unknown>;
+  import(
+    id: string,
+    opts?: JitiResolveOptions & { default?: true },
+  ): Promise<unknown>;
 
   /**
    * Resolve with ESM import conditions.

--- a/src/jiti.ts
+++ b/src/jiti.ts
@@ -141,8 +141,9 @@ export default function createJiti(
       evalModule(source: string, options?: EvalModuleOptions) {
         return evalModule(ctx, source, options);
       },
-      async import(id: string, opts?: JitiResolveOptions) {
-        return await jitiRequire(ctx, id, { ...opts, async: true });
+      async import(id: string, opts?: JitiResolveOptions & { default?: true }) {
+        const mod = await jitiRequire(ctx, id, { ...opts, async: true });
+        return opts?.default ? (mod.default ?? mod) : mod;
       },
       esmResolve(id: string, opts?: string | JitiResolveOptions): string {
         if (typeof opts === "string") {

--- a/test/bun.test.ts
+++ b/test/bun.test.ts
@@ -47,10 +47,10 @@ test("hmr", async () => {
   let value;
 
   await writeFile(tmpFile, "export default 1");
-  value = (await _jiti.import(tmpFile)) as any;
-  expect(value.default).toBe(1);
+  value = (await _jiti.import(tmpFile, { default: true })) as any;
+  expect(value).toBe(1);
 
   await writeFile(tmpFile, "export default 2");
-  value = (await _jiti.import(tmpFile)) as any;
-  expect(value.default).toBe(2);
+  value = (await _jiti.import(tmpFile, { default: true })) as any;
+  expect(value).toBe(2);
 });


### PR DESCRIPTION
Since the introduction of native ESM, a common pattern is that we need only the `default` export. A new `jiti.import(id, { default: true })` makes this easier.