### PR TITLE
feat: support generic type for `jiti.import<T>`

### DIFF
--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -18,10 +18,10 @@ export interface Jiti extends NodeRequire {
    *
    * If you need the default export of module, you can use `jiti.import(id, { default: true })` as shortcut to `mod?.default ?? mod`.
    */
-  import(
+  import<T = unknown>(
     id: string,
     opts?: JitiResolveOptions & { default?: true },
-  ): Promise<unknown>;
+  ): Promise<T>;
 
   /**
    * Resolve with ESM import conditions.

--- a/src/jiti.ts
+++ b/src/jiti.ts
@@ -141,7 +141,10 @@ export default function createJiti(
       evalModule(source: string, options?: EvalModuleOptions) {
         return evalModule(ctx, source, options);
       },
-      async import(id: string, opts?: JitiResolveOptions & { default?: true }) {
+      async import<T = unknown>(
+        id: string,
+        opts?: JitiResolveOptions & { default?: true },
+      ): Promise<T> {
         const mod = await jitiRequire(ctx, id, { ...opts, async: true });
         return opts?.default ? (mod?.default ?? mod) : mod;
       },

--- a/test/bun.test.ts
+++ b/test/bun.test.ts
@@ -47,10 +47,10 @@ test("hmr", async () => {
   let value;
 
   await writeFile(tmpFile, "export default 1");
-  value = (await _jiti.import(tmpFile, { default: true })) as any;
+  value = await _jiti.import<number>(tmpFile, { default: true });
   expect(value).toBe(1);
 
   await writeFile(tmpFile, "export default 2");
-  value = (await _jiti.import(tmpFile, { default: true })) as any;
+  value = await _jiti.import<number>(tmpFile, { default: true });
   expect(value).toBe(2);
 });


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/unjs/jiti/issues/330

### 📚 Description

Added type support 