### PR TITLE
fix: try to resolve `.ts` files with `.js` extension from js files

### DIFF
--- a/src/resolve.ts
+++ b/src/resolve.ts
@@ -66,7 +66,8 @@ export function jitiResolve(
     // Try resolving .ts files with .js extension
     if (
       TS_EXT_RE.test(ctx.filename) ||
-      TS_EXT_RE.test(ctx.parentModule?.filename || "")
+      TS_EXT_RE.test(ctx.parentModule?.filename || "") ||
+      JS_EXT_RE.test(id)
     ) {
       resolved = tryNativeRequireResolve(
         ctx,


### PR DESCRIPTION
Resolves #334

Interestingly, with this change tests still pass and the use case is fixed. The change covers a regular use case I think: id's ending with JS resolve to a file with TS extension. BUT I'm probably missing something here, so please verify.

Btw, what's your dev mode to set breakpoints in source code directly (without build, register etc), is it possible? I often do something like `tsx --inspect src/cli.ts` but didn't succeed to create something like this.