### PR TITLE
fix: interop modules with primitive default export

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "estree-walker": "^3.0.3",
     "etag": "^1.8.1",
     "fast-glob": "^3.3.2",
+    "is-installed-globally": "^1.0.0",
     "mime": "^4.0.4",
     "mlly": "^1.7.3",
     "moment-timezone": "^0.5.46",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,6 +116,9 @@ importers:
       fast-glob:
         specifier: ^3.3.2
         version: 3.3.2
+      is-installed-globally:
+        specifier: ^1.0.0
+        version: 1.0.0
       mime:
         specifier: ^4.0.4
         version: 4.0.4
@@ -1442,6 +1445,10 @@ packages:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
     hasBin: true
 
+  global-directory@4.0.1:
+    resolution: {integrity: sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==}
+    engines: {node: '>=18'}
+
   globals@11.12.0:
     resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
     engines: {node: '>=4'}
@@ -1507,6 +1514,10 @@ packages:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
 
+  ini@4.1.1:
+    resolution: {integrity: sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
   interpret@3.1.1:
     resolution: {integrity: sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==}
     engines: {node: '>=10.13.0'}
@@ -1560,9 +1571,17 @@ packages:
     engines: {node: '>=14.16'}
     hasBin: true
 
+  is-installed-globally@1.0.0:
+    resolution: {integrity: sha512-K55T22lfpQ63N4KEN57jZUAaAYqYHEe8veb/TycJRk9DdSCLLcovXz/mL6mOnhQaZsQGwPhuFopdQIlqGSEjiQ==}
+    engines: {node: '>=18'}
+
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
+
+  is-path-inside@4.0.0:
+    resolution: {integrity: sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==}
+    engines: {node: '>=12'}
 
   is-plain-object@2.0.4:
     resolution: {integrity: sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==}
@@ -3833,6 +3852,10 @@ snapshots:
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
 
+  global-directory@4.0.1:
+    dependencies:
+      ini: 4.1.1
+
   globals@11.12.0: {}
 
   globals@14.0.0: {}
@@ -3879,6 +3902,8 @@ snapshots:
 
   indent-string@4.0.0: {}
 
+  ini@4.1.1: {}
+
   interpret@3.1.1: {}
 
   is-alphabetical@1.0.4: {}
@@ -3920,7 +3945,14 @@ snapshots:
     dependencies:
       is-docker: 3.0.0
 
+  is-installed-globally@1.0.0:
+    dependencies:
+      global-directory: 4.0.1
+      is-path-inside: 4.0.0
+
   is-number@7.0.0: {}
+
+  is-path-inside@4.0.0: {}
 
   is-plain-object@2.0.4:
     dependencies:

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -106,9 +106,10 @@ function interopDefault(mod: any): any {
 
   const def = mod.default;
   const defType = typeof def;
-  if (def === null || (defType !== "object" && defType !== "function")) {
+  if (def === null || def === undefined) {
     return mod;
   }
+  const defIsObj = defType === "object" || defType === "function";
 
   return new Proxy(mod, {
     get(target, prop, receiver) {
@@ -121,11 +122,13 @@ function interopDefault(mod: any): any {
       if (Reflect.has(target, prop)) {
         return Reflect.get(target, prop, receiver);
       }
-      let fallback = Reflect.get(def, prop, receiver);
-      if (typeof fallback === "function") {
-        fallback = fallback.bind(def);
+      if (defIsObj) {
+        let fallback = Reflect.get(def, prop, receiver);
+        if (typeof fallback === "function") {
+          fallback = fallback.bind(def);
+        }
+        return fallback;
       }
-      return fallback;
     },
     apply(target, thisArg, args) {
       if (typeof target === "function") {

--- a/test/__snapshots__/fixtures.test.ts.snap
+++ b/test/__snapshots__/fixtures.test.ts.snap
@@ -11,6 +11,7 @@ exports[`fixtures > deps > stdout 1`] = `
 npm:defu {}
 npm:destr true
 npm:etag: true
+npm:is-installed-globally false
 npm:mime: true
 npm:typescript: true
 npm:moment-timezone true

--- a/test/fixtures/deps/iig.ts
+++ b/test/fixtures/deps/iig.ts
@@ -1,0 +1,3 @@
+import isInstalledGlobally from "is-installed-globally";
+
+console.log("npm:is-installed-globally", isInstalledGlobally);

--- a/test/fixtures/deps/index.ts
+++ b/test/fixtures/deps/index.ts
@@ -3,6 +3,7 @@ import "./consola";
 import "./defu";
 import "./destr";
 import "./etag";
+import "./iig";
 import "./mime";
 import "./typescript";
 import "./moment";


### PR DESCRIPTION
resolves #342

interop proxy was giving up on modules with a default export that is primitive (number, boolean, etc). Since it is not object-like to be merged.

However in cases where a native ESM module has default export, we need to preserve a proxy shape with `__esModule` hint for compact and only provide default via `.default` accessor.



This change might make regression for certain cases that **babel does not adds internal wrapper**, please report in that case.