### PR TITLE
test: simplify snapshot tests

### DIFF
--- a/test/__snapshots__/fixtures.test.ts.snap
+++ b/test/__snapshots__/fixtures.test.ts.snap
@@ -28,13 +28,18 @@ import.meta.env?.TEST true"
 `;
 
 exports[`fixtures > error-parse > stderr 1`] = `
-"[Error: ParseError: Unexpected token  
- <cwd>/index.ts:4:0]"
+[
+  "Error: ParseError: Unexpected token  ",
+]
 `;
 
 exports[`fixtures > error-parse > stdout 1`] = `""`;
 
-exports[`fixtures > error-runtime > stderr 1`] = `"test error"`;
+exports[`fixtures > error-runtime > stderr 1`] = `
+[
+  "Error: test error",
+]
+`;
 
 exports[`fixtures > error-runtime > stdout 1`] = `""`;
 
@@ -44,14 +49,7 @@ exports[`fixtures > esm > stdout 1`] = `
 {
   file: '<cwd>/test.js',
   dir: '<cwd>',
-  'import.meta.url': 'file://<cwd>/test.js',
-  stack: [
-    'at getStack (<cwd>/test)',
-    'at test (<cwd>/test)',
-    'at async <cwd>/index.js',
-    'at async Function.import (<root>/dist/jiti.cjs)',
-    'at async file://<root>/lib/jiti-cli.mjs'
-  ]
+  'import.meta.url': 'file://<cwd>/test.js'
 }"
 `;
 

--- a/test/fixtures.test.ts
+++ b/test/fixtures.test.ts
@@ -47,6 +47,14 @@ describe("fixtures", async () => {
         );
       }
 
+      function extractErrors(stderr: string) {
+        const errors = [] as string[];
+        for (const m of stderr.matchAll(/\w*(Error|Warning).*:.*$/gm)) {
+          errors.push(m[0]);
+        }
+        return errors;
+      }
+
       const { stdout, stderr } = await x("node", [jitiPath, fixtureEntry], {
         nodeOptions: {
           cwd,
@@ -59,9 +67,9 @@ describe("fixtures", async () => {
       });
 
       if (name.includes("error")) {
-        expect(cleanUpSnap(stderr)).toMatchSnapshot("stderr");
+        expect(extractErrors(cleanUpSnap(stderr))).toMatchSnapshot("stderr");
       } else {
-        // expect no error
+        // Expect no error by default
         expect(stderr).toBe("");
       }
 

--- a/test/fixtures/error-runtime/index.ts
+++ b/test/fixtures/error-runtime/index.ts
@@ -1,1 +1,1 @@
-throw "test error";
+throw new Error("test error");

--- a/test/fixtures/esm/test.js
+++ b/test/fixtures/esm/test.js
@@ -1,5 +1,3 @@
-const getStack = () => new Error("Boo").stack;
-
 require("./utils.mjs");
 
 export default async function test() {

--- a/test/fixtures/esm/test.js
+++ b/test/fixtures/esm/test.js
@@ -9,9 +9,5 @@ export default async function test() {
     file: __filename,
     dir: __dirname,
     "import.meta.url": import.meta.url,
-    stack: getStack()
-      .split("\n")
-      .splice(1)
-      .map((s) => s.trim()),
   };
 }


### PR DESCRIPTION
Simplify verbosity in snapshots to handle more node.js slight output changes in different versions