### PR TITLE
fix(cache): add `+map` suffix to fs entries when `sourceMaps` enabled

### DIFF
--- a/src/cache.ts
+++ b/src/cache.ts
@@ -22,6 +22,7 @@ export function getCache(
   // Compute cache file path
   let cacheName =
     `${basename(dirname(topts.filename))}-${filename(topts.filename)}` +
+    (ctx.opts.sourceMaps ? "+map" : "") +
     (topts.interopDefault ? ".i" : "") +
     `.${md5(topts.filename)}` +
     (topts.async ? ".mjs" : ".cjs");


### PR DESCRIPTION
resolves #347