### PR TITLE
fix: wrong babel plugin causes transform-class-properties error

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@babel/helper-plugin-utils": "^7.25.9",
     "@babel/helper-simple-access": "^7.25.9",
     "@babel/plugin-proposal-decorators": "^7.25.9",
-    "@babel/plugin-syntax-class-properties": "^7.12.13",
+    "@babel/plugin-transform-class-properties": "7.25.9",
     "@babel/plugin-syntax-import-assertions": "^7.26.0",
     "@babel/plugin-syntax-jsx": "^7.25.9",
     "@babel/plugin-transform-export-namespace-from": "^7.25.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,14 +26,14 @@ importers:
       '@babel/plugin-proposal-decorators':
         specifier: ^7.25.9
         version: 7.25.9(@babel/core@7.26.0)
-      '@babel/plugin-syntax-class-properties':
-        specifier: ^7.12.13
-        version: 7.12.13(@babel/core@7.26.0)
       '@babel/plugin-syntax-import-assertions':
         specifier: ^7.26.0
         version: 7.26.0(@babel/core@7.26.0)
       '@babel/plugin-syntax-jsx':
         specifier: ^7.25.9
+        version: 7.25.9(@babel/core@7.26.0)
+      '@babel/plugin-transform-class-properties':
+        specifier: 7.25.9
         version: 7.25.9(@babel/core@7.26.0)
       '@babel/plugin-transform-export-namespace-from':
         specifier: ^7.25.9
@@ -163,13 +163,13 @@ importers:
         version: 3.8.0
       terser-webpack-plugin:
         specifier: ^5.3.11
-        version: 5.3.11(webpack@5.97.1)
+        version: 5.3.11(webpack@5.97.1(webpack-cli@5.1.4))
       tinyexec:
         specifier: ^0.3.1
         version: 0.3.1
       ts-loader:
         specifier: ^9.5.1
-        version: 9.5.1(typescript@5.7.2)(webpack@5.97.1)
+        version: 9.5.1(typescript@5.7.2)(webpack@5.97.1(webpack-cli@5.1.4))
       typescript:
         specifier: ^5.7.2
         version: 5.7.2
@@ -190,7 +190,7 @@ importers:
         version: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack@5.97.1)
       webpack-license-plugin:
         specifier: ^4.5.0
-        version: 4.5.0(webpack@5.97.1)
+        version: 4.5.0(webpack@5.97.1(webpack-cli@5.1.4))
       yoctocolors:
         specifier: ^2.1.1
         version: 2.1.1
@@ -297,11 +297,6 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-syntax-class-properties@7.12.13':
-    resolution: {integrity: sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
   '@babel/plugin-syntax-decorators@7.25.9':
     resolution: {integrity: sha512-ryzI0McXUPJnRCvMo4lumIKZUzhYUO/ScI+Mz4YVaTLt04DHNSjEUjKVvbzQjZFLuod/cYEc07mJWhzl6v4DPg==}
     engines: {node: '>=6.9.0'}
@@ -322,6 +317,12 @@ packages:
 
   '@babel/plugin-syntax-typescript@7.25.9':
     resolution: {integrity: sha512-hjMgRy5hb8uJJjUcdWunWVcoi9bGpJp8p5Ol1229PoN6aytsLwNMgmdftO23wnCLMfVmTwZDWMPNq/D1SY60JQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-class-properties@7.25.9':
+    resolution: {integrity: sha512-bbMAII8GRSkcd0h0b4X+36GksxuheLFjP65ul9w6C3KgAamI3JqErNgSrosX6ZPj+Mpim5VvEbawXxJCyEUV3Q==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -2649,11 +2650,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.26.0)':
-    dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
-
   '@babel/plugin-syntax-decorators@7.25.9(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
@@ -2673,6 +2669,14 @@ snapshots:
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.25.9
+
+  '@babel/plugin-transform-class-properties@7.25.9(@babel/core@7.26.0)':
+    dependencies:
+      '@babel/core': 7.26.0
+      '@babel/helper-create-class-features-plugin': 7.25.9(@babel/core@7.26.0)
+      '@babel/helper-plugin-utils': 7.25.9
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/plugin-transform-export-namespace-from@7.25.9(@babel/core@7.26.0)':
     dependencies:
@@ -3298,17 +3302,17 @@ snapshots:
       '@webassemblyjs/ast': 1.14.1
       '@xtuc/long': 4.2.2
 
-  '@webpack-cli/configtest@2.1.1(webpack-cli@5.1.4)(webpack@5.97.1)':
+  '@webpack-cli/configtest@2.1.1(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack@5.97.1))(webpack@5.97.1(webpack-cli@5.1.4))':
     dependencies:
       webpack: 5.97.1(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack@5.97.1)
 
-  '@webpack-cli/info@2.0.2(webpack-cli@5.1.4)(webpack@5.97.1)':
+  '@webpack-cli/info@2.0.2(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack@5.97.1))(webpack@5.97.1(webpack-cli@5.1.4))':
     dependencies:
       webpack: 5.97.1(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack@5.97.1)
 
-  '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4)(webpack@5.97.1)':
+  '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack@5.97.1))(webpack@5.97.1(webpack-cli@5.1.4))':
     dependencies:
       webpack: 5.97.1(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack@5.97.1)
@@ -4572,7 +4576,7 @@ snapshots:
       mkdirp: 1.0.4
       yallist: 4.0.0
 
-  terser-webpack-plugin@5.3.11(webpack@5.97.1):
+  terser-webpack-plugin@5.3.11(webpack@5.97.1(webpack-cli@5.1.4)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       jest-worker: 27.5.1
@@ -4614,7 +4618,7 @@ snapshots:
     dependencies:
       typescript: 5.7.2
 
-  ts-loader@9.5.1(typescript@5.7.2)(webpack@5.97.1):
+  ts-loader@9.5.1(typescript@5.7.2)(webpack@5.97.1(webpack-cli@5.1.4)):
     dependencies:
       chalk: 4.1.2
       enhanced-resolve: 5.17.1
@@ -4766,9 +4770,9 @@ snapshots:
   webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack@5.97.1):
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
-      '@webpack-cli/configtest': 2.1.1(webpack-cli@5.1.4)(webpack@5.97.1)
-      '@webpack-cli/info': 2.0.2(webpack-cli@5.1.4)(webpack@5.97.1)
-      '@webpack-cli/serve': 2.0.5(webpack-cli@5.1.4)(webpack@5.97.1)
+      '@webpack-cli/configtest': 2.1.1(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack@5.97.1))(webpack@5.97.1(webpack-cli@5.1.4))
+      '@webpack-cli/info': 2.0.2(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack@5.97.1))(webpack@5.97.1(webpack-cli@5.1.4))
+      '@webpack-cli/serve': 2.0.5(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack@5.97.1))(webpack@5.97.1(webpack-cli@5.1.4))
       colorette: 2.0.20
       commander: 10.0.1
       cross-spawn: 7.0.6
@@ -4782,7 +4786,7 @@ snapshots:
     optionalDependencies:
       webpack-bundle-analyzer: 4.10.2
 
-  webpack-license-plugin@4.5.0(webpack@5.97.1):
+  webpack-license-plugin@4.5.0(webpack@5.97.1(webpack-cli@5.1.4)):
     dependencies:
       chalk: 5.3.0
       lodash: 4.17.21
@@ -4821,7 +4825,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.11(webpack@5.97.1)
+      terser-webpack-plugin: 5.3.11(webpack@5.97.1(webpack-cli@5.1.4))
       watchpack: 2.4.2
       webpack-sources: 3.2.3
     optionalDependencies:

--- a/src/_types/babel-plugin-syntax-class-properties.d.ts
+++ b/src/_types/babel-plugin-syntax-class-properties.d.ts
@@ -1,5 +1,0 @@
-declare module "@babel/plugin-syntax-class-properties" {
-  import type { declare } from "@babel/helper-plugin-utils";
-  const syntaxClassPropertiesPlugin: ReturnType<typeof declare>;
-  export default syntaxClassPropertiesPlugin;
-}

--- a/src/_types/babel-plugin-transform-class-properties.d.ts
+++ b/src/_types/babel-plugin-transform-class-properties.d.ts
@@ -1,0 +1,5 @@
+declare module "@babel/plugin-transform-class-properties" {
+  import type { declare } from "@babel/helper-plugin-utils";
+  const transformClassPropertiesPlugin: ReturnType<typeof declare>;
+  export default transformClassPropertiesPlugin;
+}

--- a/src/babel.ts
+++ b/src/babel.ts
@@ -4,7 +4,7 @@ import type {
 } from "@babel/core";
 import { transformSync } from "@babel/core";
 import proposalDecoratorsPlugin from "@babel/plugin-proposal-decorators";
-import syntaxClassPropertiesPlugin from "@babel/plugin-syntax-class-properties";
+import transformClassPropertiesPlugin from "@babel/plugin-transform-class-properties";
 import syntaxImportAssertionsPlugin from "@babel/plugin-syntax-import-assertions";
 import syntaxJSXPlugin from "@babel/plugin-syntax-jsx";
 import transformExportNamespaceFromPlugin from "@babel/plugin-transform-export-namespace-from";
@@ -40,7 +40,7 @@ export default function transform(opts: TransformOptions): TransformResult {
       [importMetaPathsPlugin, { filename: opts.filename }],
       [importMetaEnvPlugin],
       [importMetaResolvePlugin],
-      [syntaxClassPropertiesPlugin],
+      [transformClassPropertiesPlugin],
       [transformExportNamespaceFromPlugin],
     ],
   };
@@ -60,7 +60,7 @@ export default function transform(opts: TransformOptions): TransformResult {
         isTSX: opts.jsx && /\.[cm]?tsx$/.test(opts.filename || ""),
       },
     ]);
-    // `unshift` because these plugin must come before `@babel/plugin-syntax-class-properties`
+    // `unshift` because these plugin must come before `@babel/plugin-transform-class-properties`
     _opts.plugins.unshift(
       [transformTypeScriptMetaPlugin],
       [proposalDecoratorsPlugin, { legacy: true }],


### PR DESCRIPTION
# Resolves

This PR resolves  [Originally posted by @cshomo11 in #57](https://github.com/unjs/jiti/issues/57#issuecomment-1335569520)

# MWE

[MWE (minimal reproduction) repository](https://github.com/Fgc17/jiti-transform-class-properties-error)

For testing the MWE, just hit `pnpm install` and then `pnpm working` or `pnpm not-working`.

# Description

We should not be using the `babel-plugin-syntax-class-properties`:

![image](https://github.com/user-attachments/assets/9668f086-50ac-40f5-a54a-14d76323ed5a)

Just as written in the babel docs, the plugin does not bring transform, so it causes an issue with `class-transfomer` (and probably other packages):

```bash
[jiti] [init] version: 2.4.2 module-cache: true fs-cache: false interop-defaults: true
[jiti] [transpile] [esm] ./src/class-validator/env.config.ts (51.721ms)
[jiti] [native] [import] workspace/my-lib/packages/my-lib/dist/core/core.cjs
[jiti] [native] [import] workspace/my-lib/node_modules/.pnpm/dotenv@16.4.7/node_modules/dotenv/lib/main.js
[jiti] [native] [import] workspace/my-lib/node_modules/.pnpm/class-validator@0.14.1/node_modules/class-validator/cjs/index.js
[jiti] [native] [import] workspace/my-lib/node_modules/.pnpm/class-transformer@0.5.1/node_modules/class-transformer/cjs/index.js
workspace/my-lib/packages/playground/src/class-validator/env.config.ts:7
<TRANSPILED CODE THAT FAILED GOES HERE>

Error: Decorating class property failed. Please ensure that transform-class-properties is enabled and runs after the decorators transform.
    at _initializerWarningHelper (workspace/my-lib/packages/playground/src/class-validator/env.config.ts:7:767)
    at <instance_members_initializer> (workspace/my-lib/packages/playground/src/class-validator/env.config.ts:13:141)
    at new Schema (workspace/my-lib/packages/playground/src/class-validator/env.config.ts:13:116)
    at TransformOperationExecutor.transform (workspace/my-lib/node_modules/.pnpm/class-transformer@0.5.1/node_modules/class-transformer/cjs/TransformOperationExecutor.js:147:32)
    at ClassTransformer.plainToInstance (workspace/my-lib/node_modules/.pnpm/class-transformer@0.5.1/node_modules/class-transformer/cjs/ClassTransformer.js:27:25)
    at plainToInstance (workspace/my-lib/node_modules/.pnpm/class-transformer@0.5.1/node_modules/class-transformer/cjs/index.js:38:29)
    at validate (workspace/my-lib/packages/playground/src/class-validator/env.config.ts:27:60)
    at Command.<anonymous> (workspace/my-lib/packages/my-lib/dist/cli/cli.cjs:334:39)

Node.js v22.3.0
 ELIFECYCLE  Command failed with exit code 1.
```

The only fix without merging is including the plugin by yourself:
```ts
import pluginTransformClassProperties from "@babel/plugin-transform-class-properties";

const jiti = createJiti(import.meta.url, {
   transformOptions: {
     ts: true,
     babel: {
       plugins: [pluginTransformClassProperties],
     },
   },
 });
```

## Transpiled code that failed
```js
var _classTransformer = await jitiImport("class-transformer");
var _dec, _dec2, _dec3, _dec4, _class, _descriptor, _descriptor2;
function _interopRequireDefault(e) {
    return e && e.__esModule ? e : { default: e };
}
function _applyDecoratedDescriptor(i, e, r, n, l) {
    var a = {};
    return (
        Object.keys(n).forEach(function (i) {
            a[i] = n[i];
        }),
        (a.enumerable = !!a.enumerable),
        (a.configurable = !!a.configurable),
        ("value" in a || a.initializer) && (a.writable = !0),
        (a = r
            .slice()
            .reverse()
            .reduce(function (r, n) {
                return n(i, e, r) || r;
            }, a)),
        l && void 0 !== a.initializer && ((a.value = a.initializer ? a.initializer.call(l) : void 0), (a.initializer = void 0)),
        void 0 === a.initializer ? (Object.defineProperty(i, e, a), null) : a
    );
}
function _initializerWarningHelper(r, e) {
    throw Error("Decorating class property failed. Please ensure that transform-class-properties is enabled and runs after the decorators transform.");
}
let;
```

