### PR TITLE
feat: enhance transform and evalModule to support async callbacks

### DIFF
--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -35,12 +35,12 @@ export interface Jiti extends NodeRequire {
   /**
    * Transform source code
    */
-  transform: (opts: TransformOptions, cb?: (source: string) => string) => Promise<string>;
+  transform: (opts: TransformOptions, sourceTransformer?: (source: string) => string) => Promise<string>;
 
   /**
    * Evaluate transformed code as a module
    */
-  evalModule: (source: string, options?: EvalModuleOptions, cb?: (source: string, filename: string) => Promise<string> | string) => unknown;
+  evalModule: (source: string, options?: EvalModuleOptions, sourceTransformer?: (source: string, filename: string) => Promise<string> | string) => unknown;
 }
 
 /**

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -35,12 +35,12 @@ export interface Jiti extends NodeRequire {
   /**
    * Transform source code
    */
-  transform: (opts: TransformOptions) => string;
+  transform: (opts: TransformOptions, cb?: (source: string) => string) => Promise<string>;
 
   /**
    * Evaluate transformed code as a module
    */
-  evalModule: (source: string, options?: EvalModuleOptions) => unknown;
+  evalModule: (source: string, options?: EvalModuleOptions, cb?: (source: string, filename: string) => Promise<string> | string) => unknown;
 }
 
 /**

--- a/src/eval.ts
+++ b/src/eval.ts
@@ -19,7 +19,7 @@ export async function evalModule(
   ctx: Context,
   source: string,
   evalOptions: EvalModuleOptions = {},
-  cb?: (source: string, filename: string) => Promise<string> | string,
+  sourceTransformer?: (source: string, filename: string) => Promise<string> | string,
 ): Promise<any> {
   // Resolve options
   const id =
@@ -52,7 +52,7 @@ export async function evalModule(
       ts: isTypescript,
       async: evalOptions.async ?? false,
       jsx: ctx.opts.jsx,
-    }, cb);
+    }, sourceTransformer);
     const time = Math.round((performance.now() - start) * 1000) / 1000;
     console.log('filename' , filename)
     debug(
@@ -93,7 +93,7 @@ export async function evalModule(
           ts: isTypescript,
           async: evalOptions.async ?? false,
           jsx: ctx.opts.jsx,
-        }, cb);
+        }, sourceTransformer);
       }
     }
   }

--- a/src/jiti.ts
+++ b/src/jiti.ts
@@ -5,6 +5,7 @@ import type {
   Context,
   EvalModuleOptions,
   JitiResolveOptions,
+  SourceTransformer,
 } from "./types";
 import { platform } from "node:os";
 import { pathToFileURL } from "mlly";
@@ -27,11 +28,7 @@ export default function createJiti(
   userOptions: JitiOptions = {},
   parentContext: Pick<
     Context,
-    | "parentModule"
-    | "parentCache"
-    | "nativeImport"
-    | "onError"
-    | "createRequire"
+    "parentModule" | "parentCache" | "nativeImport" | "onError" | "createRequire" | "callbackStore"
   >,
   isNested = false,
 ): Jiti {
@@ -96,6 +93,7 @@ export default function createJiti(
     parentCache: parentContext.parentCache,
     nativeImport: parentContext.nativeImport,
     createRequire: parentContext.createRequire,
+    callbackStore: parentContext.callbackStore,
   };
 
   // Debug
@@ -135,11 +133,11 @@ export default function createJiti(
           paths: nativeRequire.resolve.paths,
         },
       ),
-      transform(opts: TransformOptions) {
-        return transform(ctx, opts);
+      transform(opts: TransformOptions, sourceTransformer?: SourceTransformer) {
+        return transform(ctx, opts, sourceTransformer);
       },
-      evalModule(source: string, options?: EvalModuleOptions) {
-        return evalModule(ctx, source, options);
+      evalModule(source: string, options?: EvalModuleOptions, sourceTransformer?: SourceTransformer) {
+        return evalModule(ctx, source, options, sourceTransformer);
       },
       async import<T = unknown>(
         id: string,

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -1,30 +1,45 @@
-import type { Context, TransformOptions } from "./types";
+import type { Context, TransformOptions, SourceTransformer } from "./types";
 import { getCache } from "./cache";
 import { debug } from "./utils";
 
-export function transform(ctx: Context, topts: TransformOptions): string {
-  let code = getCache(ctx, topts, () => {
-    const res = ctx.opts.transform!({
+export async function transform(ctx: Context, topts: TransformOptions, sourceTransformer?: SourceTransformer): Promise<string> {
+  if (!topts.filename) {
+    throw new Error("transform: filename is required");
+  }
+
+  // Initialize or update callback store
+  ctx.callbackStore ??= new Map();
+  if (sourceTransformer) {
+    ctx.callbackStore.set('sourceTransformer', sourceTransformer);
+  }
+
+  let source = topts.source;
+  const globalTransformer = ctx.callbackStore?.get('sourceTransformer');
+
+
+  if (globalTransformer) {
+    try {
+      source = await globalTransformer(source, topts.filename!);
+    } catch (error_) {
+      debug(ctx, 'Source transformer error:', error_);
+    }
+  }
+
+  const code = getCache(ctx, topts, () => {
+    return ctx.opts.transform!({
       ...ctx.opts.transformOptions,
       babel: {
-        ...(ctx.opts.sourceMaps
-          ? {
-              sourceFileName: topts.filename,
-              sourceMaps: "inline",
-            }
-          : {}),
+        ...(ctx.opts.sourceMaps ? {
+          sourceFileName: topts.filename,
+          sourceMaps: "inline",
+        } : {}),
         ...ctx.opts.transformOptions?.babel,
       },
       interopDefault: ctx.opts.interopDefault,
       ...topts,
-    });
-    if (res.error && ctx.opts.debug) {
-      debug(ctx, res.error);
-    }
-    return res.code;
+      source,
+    }).code;
   });
-  if (code.startsWith("#!")) {
-    code = "// " + code;
-  }
-  return code;
+  
+  return code.startsWith("#!") ? "// " + code : code;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,4 +25,13 @@ export interface Context {
   additionalExts: string[];
   nativeRequire: NodeRequire;
   createRequire: (typeof import("node:module"))["createRequire"];
+  callbackStore?: Map<string, SourceTransformer>;
+}
+
+export type SourceTransformer = (source: string, filename: string) => Promise<string> | string;
+
+export interface CacheOptions {
+  key: string;
+  invalidate?: boolean;
+  transform?: () => string | Promise<string>;
 }


### PR DESCRIPTION
cc: #363 

In some setups like Unimport, we need to modify the source to add imports at the beginning of each content. Since sourceTransformer is empty every time the eval mode transform runs, I store and cache it to reuse later.

Example code:

```ts
  const jiti = createJiti(silgi.options.rootDir, {
    fsCache: false,
    moduleCache: false,
    debug: true,
    alias: test.options.alias,
  })


  const test = await jiti.evalModule(
    injectedResult.code,
    {
      filename: path,
      async: true,
    },
    async (data, name) => {
      return (await silgi.unimport!.injectImports(data, name)).code
    },
  )
```