### PR TITLE
perf: always use jiti/native in Deno

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,10 @@
   "type": "module",
   "exports": {
     ".": {
+      "deno": {
+        "types": "./lib/jiti.d.mts",
+        "import": "./lib/jiti-native.mjs"
+      },
       "import": {
         "types": "./lib/jiti.d.mts",
         "default": "./lib/jiti.mjs"


### PR DESCRIPTION
Deno already supports ESM/CJS interop, TypeScript, and tsx out of the box. It also doesn't have loader hooks for ESM anyway, so there is no point in trying to do that in Deno. Instead, we can always pass through to the native runtime functions.