### PR TITLE
perf: lazy load babel transform

### DIFF
--- a/lib/jiti.cjs
+++ b/lib/jiti.cjs
@@ -1,6 +1,5 @@
 const { createRequire } = require("node:module");
 const _createJiti = require("../dist/jiti.cjs");
-const transform = require("../dist/babel.cjs");
 
 function onError(err) {
   throw err; /* ↓ Check stack trace ↓ */
@@ -8,9 +7,17 @@ function onError(err) {
 
 const nativeImport = (id) => import(id);
 
+let _transform;
+function lazyTransform(...args) {
+  if (!_transform) {
+    _transform = require("../dist/babel.cjs");
+  }
+  return _transform(...args);
+}
+
 function createJiti(id, opts = {}) {
   if (!opts.transform) {
-    opts = { ...opts, transform };
+    opts = { ...opts, transform: lazyTransform };
   }
   return _createJiti(id, opts, {
     onError,

--- a/lib/jiti.mjs
+++ b/lib/jiti.mjs
@@ -1,6 +1,5 @@
 import { createRequire } from "node:module";
 import _createJiti from "../dist/jiti.cjs";
-import transform from "../dist/babel.cjs";
 
 function onError(err) {
   throw err; /* ↓ Check stack trace ↓ */
@@ -8,9 +7,18 @@ function onError(err) {
 
 const nativeImport = (id) => import(id);
 
+let _transform;
+function lazyTransform(...args) {
+  if (!_transform) {
+    const { require } = createRequire(import.meta.url);
+    _transform = require("../dist/babel.cjs");
+  }
+  return _transform(...args);
+}
+
 export function createJiti(id, opts = {}) {
   if (!opts.transform) {
-    opts = { ...opts, transform };
+    opts = { ...opts, transform: lazyTransform };
   }
   return _createJiti(id, opts, {
     onError,


### PR DESCRIPTION
This PR optimizes init time by lazy importing Babel transformer only if needed (transform needed, cache missing, and native also not possible)

## Benchmak

Before: (load:83ms + import:39ms)

```
> node v22.14.0
jiti:load: 83.076ms
jiti:load: +17.93 MB (heap)
jiti:init: 0.517ms
jiti:import:ts: 39.263ms
jiti:import:ts: 7.963ms
jiti:import:ts: 8.329ms
jiti:import:ts: 7.955ms
--------------------------------
> deno 2.5.1
jiti:load: 124ms
jiti:load: +20.03 MB (heap)
jiti:init: 0.579ms
jiti:import:ts: 45.1ms
jiti:import:ts: 11.4ms
jiti:import:ts: 9.96ms
jiti:import:ts: 8.91ms
--------------------------------
> bun 1.2.21
[81.33ms] jiti:load
jiti:load: +0.00 MB (heap)
[0.50ms] jiti:init
[3.45ms] jiti:import:ts
[1.72ms] jiti:import:ts
[2.87ms] jiti:import:ts
[1.18ms] jiti:import:ts
```

After: (load:8.8ms + lazy-import: 108ms)

```
> node v22.14.0
jiti:load: 8.824ms
jiti:load: +1.07 MB (heap)
jiti:init: 0.478ms
jiti:import:ts: 108.271ms
jiti:import:ts: 7.452ms
jiti:import:ts: 6.475ms
jiti:import:ts: 9.583ms
--------------------------------
> deno 2.5.1
jiti:load: 4.17ms
jiti:load: +1.30 MB (heap)
jiti:init: 0.620ms
jiti:import:ts: 159ms
jiti:import:ts: 12.7ms
jiti:import:ts: 9.45ms
jiti:import:ts: 8.96ms
--------------------------------
> bun 1.2.21
[20.72ms] jiti:load
jiti:load: +0.00 MB (heap)
[0.53ms] jiti:init
[3.64ms] jiti:import:ts
[2.01ms] jiti:import:ts
[1.72ms] jiti:import:ts
[1.07ms] jiti:import:ts
``