### PR TITLE
build: revert to `terser-webpack-plugin`

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
     "reflect-metadata": "^0.2.2",
     "solid-js": "^1.9.9",
     "std-env": "^3.9.0",
+    "terser-webpack-plugin": "^5.3.14",
     "tinyexec": "^1.0.1",
     "ts-loader": "^9.5.4",
     "typescript": "^5.9.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -167,6 +167,9 @@ importers:
       std-env:
         specifier: ^3.9.0
         version: 3.9.0
+      terser-webpack-plugin:
+        specifier: ^5.3.14
+        version: 5.3.14(webpack@5.101.3)
       tinyexec:
         specifier: ^1.0.1
         version: 1.0.1

--- a/rspack.config.mjs
+++ b/rspack.config.mjs
@@ -58,6 +58,8 @@ export default defineConfig({
     chunkIds: "named",
     minimize: true,
     minimizer: [
+      // TODO: Migrate to rspack.SwcJsMinimizerRspackPlugin
+      // https://github.com/unjs/jiti/pull/407
       new TerserPlugin({
         terserOptions: {
           mangle: {

--- a/rspack.config.mjs
+++ b/rspack.config.mjs
@@ -1,5 +1,5 @@
 import { fileURLToPath } from "node:url";
-import { rspack } from "@rspack/core";
+import TerserPlugin from 'terser-webpack-plugin'
 import { defineConfig } from "@rspack/cli";
 
 export default defineConfig({
@@ -58,8 +58,8 @@ export default defineConfig({
     chunkIds: "named",
     minimize: true,
     minimizer: [
-      new rspack.SwcJsMinimizerRspackPlugin({
-        minimizerOptions: {
+      new TerserPlugin({
+        terserOptions: {
           mangle: {
             keep_fnames: true,
             keep_classnames: true,

--- a/test/__snapshots__/fixtures.test.ts.snap
+++ b/test/__snapshots__/fixtures.test.ts.snap
@@ -119,6 +119,7 @@ Decorator called with 3 arguments.
 Decorator called with 3 arguments.
 Decorator called with 3 arguments.
 Decorator called with 1 arguments.
+foo
 {
   file: '<cwd>/test.ts',
   dir: '<cwd>',

--- a/test/fixtures/typescript/index.ts
+++ b/test/fixtures/typescript/index.ts
@@ -4,6 +4,7 @@ import { test as satisfiesTest } from "./satisfies";
 import { child } from "./parent.mjs";
 // @ts-expect-error (needs allowImportingTsExtensions)
 import defPromise from "./def-promise.cts";
+import "./namespace";
 
 export type { Test } from "./types";
 

--- a/test/fixtures/typescript/namespace.ts
+++ b/test/fixtures/typescript/namespace.ts
@@ -1,0 +1,8 @@
+export {};
+
+// eslint-disable-next-line @typescript-eslint/no-namespace
+namespace MyNamespace {
+  export const value = "foo";
+}
+
+console.log(MyNamespace.value);


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->
resolves https://github.com/unjs/jiti/issues/406

Revert from `rspack.SwcJsMinimizerRspackPlugin` back to `terser-webpack-plugin` due to a bundle issue. 
(This is a quick fix, more details need to be investigated)

As for the bundle size:

|`rspack.SwcJsMinimizerRspackPlugin`|`terser-webpack-plugin`|
|:-|:-|
|dist/jiti.cjs: `48,555 B`| dist/jiti.cjs: `48,382 B`|