### PR TITLE
feat: support `virtualModules` option

### DIFF
--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -247,6 +247,26 @@ export interface JitiOptions {
   jsx?: boolean | JSXOptions;
 
   /**
+   * Virtual modules - pre-loaded module objects that bypass filesystem resolution.
+   * Useful for bundled modules in compiled binaries (e.g., Bun).
+   *
+   * When a module ID matches a key in this map, the corresponding value is
+   * returned directly without any filesystem resolution or transformation.
+   *
+   * @example
+   * ```ts
+   * import * as typebox from "@sinclair/typebox";
+   *
+   * const jiti = createJiti(import.meta.url, {
+   *   virtualModules: {
+   *     "@sinclair/typebox": typebox,
+   *   },
+   * });
+   * ```
+   */
+  virtualModules?: Record<string, unknown>;
+
+  /**
    * Enable tsconfig paths resolution.
    *
    * - `true`: auto-discover `tsconfig.json` by walking up from the

--- a/src/require.ts
+++ b/src/require.ts
@@ -35,6 +35,15 @@ export function jitiRequire(
     return nativeImportOrRequire(ctx, id, opts.async);
   }
 
+  // Check for virtual modules (e.g., bundled modules in compiled Bun binaries)
+  if (ctx.opts.virtualModules && id in ctx.opts.virtualModules) {
+    debug(ctx, "[virtual]", id);
+    const mod = ctx.opts.virtualModules[id];
+    return opts.async
+      ? Promise.resolve(jitiInteropDefault(ctx, mod))
+      : jitiInteropDefault(ctx, mod);
+  }
+
   // Experimental Bun support
   if (ctx.opts.tryNative && !ctx.opts.transformOptions) {
     try {

--- a/test/virtual-modules.test.ts
+++ b/test/virtual-modules.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { createJiti } from "../lib/jiti.mjs";
+
+describe("virtualModules", () => {
+  const virtualMod = {
+    default: "hello",
+    foo: 42,
+  };
+
+  it("sync require returns virtual module", () => {
+    const jiti = createJiti(import.meta.url, {
+      virtualModules: {
+        "my-virtual-mod": virtualMod,
+      },
+    });
+    const result = jiti("my-virtual-mod");
+    expect(result).toMatchObject({ default: "hello", foo: 42 });
+  });
+
+  it("async import returns virtual module", async () => {
+    const jiti = createJiti(import.meta.url, {
+      virtualModules: {
+        "my-virtual-mod": virtualMod,
+      },
+    });
+    const result = await jiti.import("my-virtual-mod");
+    expect(result).toMatchObject({ default: "hello", foo: 42 });
+  });
+
+  it("falls through to normal resolution when not in virtualModules", () => {
+    const jiti = createJiti(import.meta.url, {
+      virtualModules: {},
+    });
+    // node:path should resolve normally
+    const result = jiti("node:path");
+    expect(result.join).toBeDefined();
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    include: ["test/fixtures.test.ts", "test/utils.test.ts"],
+    include: ["test/fixtures.test.ts", "test/utils.test.ts", "test/virtual-modules.test.ts"],
     coverage: {
       reporter: ["text", "clover", "json"],
       include: ["src/**/*.ts"],


### PR DESCRIPTION
Add `virtualModules` option to bypass filesystem resolution for pre-loaded module objects. Useful for bundled modules in compiled binaries (e.g., Bun).

## Changes

- Add `virtualModules?: Record<string, unknown>` to `JitiOptions`
- Check virtual modules in `jitiRequire` before filesystem resolution (supports both sync and async)
- Add test coverage

Co-authored-by: Mario Zechner (https://github.com/badlogic/jiti/commit/ad402d33c4739da658751c391e680297c28662af)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Virtual modules support added to the loader configuration, enabling pre-loaded module objects that bypass filesystem resolution.

* **Tests**
  * Comprehensive test suite added for virtual modules functionality, validating synchronous and asynchronous module loading, and ensuring proper fallback to standard resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->