### PR TITLE
feat: add `jiti/static` export

### DIFF
--- a/lib/jiti-static.mjs
+++ b/lib/jiti-static.mjs
@@ -1,0 +1,23 @@
+import { createRequire } from "node:module";
+import _createJiti from "../dist/jiti.cjs";
+// Static import so Bun bundles babel.cjs into compiled binaries
+import _babelTransform from "../dist/babel.cjs";
+
+function onError(err) {
+  throw err; /* ↓ Check stack trace ↓ */
+}
+
+const nativeImport = (id) => import(id);
+
+export function createJiti(id, opts = {}) {
+  if (!opts.transform) {
+    opts = { ...opts, transform: _babelTransform };
+  }
+  return _createJiti(id, opts, {
+    onError,
+    nativeImport,
+    createRequire,
+  });
+}
+
+export default createJiti;

--- a/package.json
+++ b/package.json
@@ -24,6 +24,10 @@
       "types": "./lib/jiti.d.mts",
       "import": "./lib/jiti-native.mjs"
     },
+    "./static": {
+      "types": "./lib/jiti.d.mts",
+      "import": "./lib/jiti-static.mjs"
+    },
     "./package.json": "./package.json"
   },
   "main": "./lib/jiti.cjs",
@@ -35,6 +39,9 @@
         "./lib/jiti-register.d.mts"
       ],
       "native": [
+        "./lib/jiti.d.mts"
+      ],
+      "static": [
         "./lib/jiti.d.mts"
       ]
     }


### PR DESCRIPTION
Adds a new `jiti/static` export that statically imports `babel.cjs` instead of lazy-loading it via `createRequire(import.meta.url)`.

Closes #417

This solves two use cases:
- **Bun compiled binaries**: ensures `babel.cjs` gets bundled into the binary
- **Webpack/bundler compatibility**: the lazy `createRequire(import.meta.url)` pattern breaks when bundlers rewrite `import.meta.url` to a hardcoded path. A static import lets bundlers resolve and include `babel.cjs` correctly.

Usage:
```js
import { createJiti } from "jiti/static";
```

Based on https://github.com/badlogic/jiti/commit/800a4fc547273afa40a9c7ca1d7e0166542f8ce8

Co-authored-by: Mario Zechner <badlogicgames@gmail.com>