### PR TITLE
fix(require): normalize windows paths for native import when tryNative is true

### DIFF
--- a/src/require.ts
+++ b/src/require.ts
@@ -59,7 +59,7 @@ export function jitiRequire(
       );
       if (opts.async && ctx.nativeImport) {
         return ctx
-          .nativeImport(id)
+          .nativeImport(normalizeWindowsImportId(id))
           .then((m: any) => {
             if (ctx.opts.moduleCache === false) {
               delete ctx.nativeRequire.cache[id];

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -164,11 +164,11 @@ function interopDefault(mod: any): any {
   });
 }
 
-export function normalizeWindowsImportId(id: string) {
+export function normalizeWindowsImportId(id: string): string {
   if (!isWindows || !isAbsolute(id)) {
     return id;
   }
-  return pathToFileURL(id);
+  return pathToFileURL(id).toString();
 }
 
 let _fipsMode: boolean | undefined;


### PR DESCRIPTION
## Summary
- Fixes `ERR_UNSUPPORTED_ESM_URL_SCHEME` on Windows when `tryNative` is true and Jiti falls back to transpilation.
- During fallback, if a module contains a dynamic `import()`, Jiti transforms it to `jiti.import()`, which internally calls `ctx.nativeImport()` with `opts.async = true`.
- On Windows, Node's native `import()` requires absolute paths to be `file://` URLs. This PR uses the existing `normalizeWindowsImportId` helper to convert paths before passing them to `nativeImport()`.

## Test plan
- Ran `pnpm test` successfully.
- Verified that all 28 fixtures pass.
- Ensured no regressions in native or CJS interop.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured Windows import path normalization is applied consistently for native async imports, matching other import paths and preventing import failures.
  * Normalization utility now consistently returns a string for absolute Windows paths, removing edge-case type inconsistencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->