### PR TITLE
fix(interopDefault): skip bind for Symbol properties

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -150,7 +150,7 @@ function interopDefault(mod: any): any {
         value = target[prop];
       } else if (needsDefaultFallback) {
         value = def[prop];
-        if (typeof value === "function") {
+        if (typeof value === "function" && typeof prop !== "symbol") {
           value = value.bind(def);
         }
       }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -150,7 +150,13 @@ function interopDefault(mod: any): any {
         value = target[prop];
       } else if (needsDefaultFallback) {
         value = def[prop];
-        if (typeof value === "function" && typeof prop !== "symbol") {
+        if (
+          typeof value === "function" &&
+          // Skip bind for disposal symbols — V8 rejects bound functions
+          // with native `await using` / `using` (Node 24+)
+          prop !== Symbol.asyncDispose &&
+          prop !== Symbol.dispose
+        ) {
           value = value.bind(def);
         }
       }


### PR DESCRIPTION
## Problem

`interopDefault` in `src/utils.ts` wraps fall-through methods with `Function.prototype.bind` to preserve `this` for the underlying default export. When the property accessed is `Symbol.asyncDispose` / `Symbol.dispose` and the consumer uses native `await using` / `using` (Node 24+), V8 rejects the bound function returned through the proxy `get` trap with:

```
TypeError: Symbol(Symbol.asyncDispose) is not a function
```

This does **not** surface when the calling file is itself transpiled by jiti, because Babel rewrites `await using` to a `DisposableStack` helper that calls the bound function directly.

## Fix

Skip `Function.prototype.bind()` for Symbol properties in the `interopDefault` proxy `get` trap. Symbol properties like `Symbol.asyncDispose` and `Symbol.dispose` are protocol methods that should maintain their original reference identity.

```diff
- if (typeof value === "function") {
+ if (typeof value === "function" && typeof prop !== "symbol") {
    value = value.bind(def);
  }
```

## Testing

Tested with Node 24+ using the minimal reproduction from #437:

```js
// repro.mjs
import { createRequire } from "node:module";
const jiti = createRequire(import.meta.url);
const mod = jiti("./disposable.mjs");
await using res = mod;
```

Fixes #437

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an interoperability issue where accessing special disposal-related properties on default exports could cause incorrect function binding.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unjs/jiti/pull/441)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->