### PR TITLE
feat: pass `filename` to the Babel transform

### DIFF
--- a/src/babel.ts
+++ b/src/babel.ts
@@ -26,7 +26,7 @@ export default function transform(opts: TransformOptions): TransformResult {
     compact: false,
     retainLines:
       typeof opts.retainLines === "boolean" ? opts.retainLines : true,
-    filename: "",
+    filename: opts.filename ?? "",
     cwd: "/",
     ...opts.babel,
     plugins: [

--- a/test/__snapshots__/fixtures.test.ts.snap
+++ b/test/__snapshots__/fixtures.test.ts.snap
@@ -31,7 +31,7 @@ import.meta.env?.TEST true"
 
 exports[`fixtures > error-parse > stderr 1`] = `
 [
-  "Error: ParseError: Unexpected token  ",
+  "Error: ParseError: <cwd>/index.ts: Unexpected token  ",
 ]
 `;
 

--- a/test/transform-options.test.ts
+++ b/test/transform-options.test.ts
@@ -1,0 +1,45 @@
+import * as path from "node:path";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import { describe, it, expect } from "vitest";
+import { createJiti } from "../lib/jiti.mjs";
+import type { PluginObj } from "@babel/core";
+
+describe("transformOptions", () => {
+  it("exposes the file path to a custom babel plugin", async () => {
+    const fixture = path.join(
+      os.tmpdir(),
+      `jiti-transform-options-${Date.now()}.ts`,
+    );
+    await fs.writeFile(fixture, `export const value: number = 42;\n`);
+
+    const seenFilenames: string[] = [];
+    const recordFilenamePlugin = (): PluginObj => ({
+      visitor: {
+        Program(_, { filename }) {
+          if (filename) {
+            seenFilenames.push(filename);
+          }
+        },
+      },
+    });
+
+    try {
+      const jiti = createJiti(import.meta.url, {
+        cache: false,
+        transformOptions: {
+          babel: {
+            plugins: [recordFilenamePlugin],
+          },
+        },
+      });
+
+      const mod = (await jiti.import(fixture)) as any;
+
+      expect(mod.value).toBe(42);
+      expect(seenFilenames).toContain(fixture);
+    } finally {
+      await fs.unlink(fixture);
+    }
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    include: ["test/fixtures.test.ts", "test/utils.test.ts", "test/virtual-modules.test.ts", "test/esm-temp-file.test.ts"],
+    include: ["test/fixtures.test.ts", "test/utils.test.ts", "test/virtual-modules.test.ts", "test/esm-temp-file.test.ts", "test/transform-options.test.ts"],
     coverage: {
       reporter: ["text", "clover", "json"],
       include: ["src/**/*.ts"],


### PR DESCRIPTION
Resolves #442 

Passes the file name from the transform options into the `filename` setting of Babel.
Added a test to check that it's received on the Babel plugin side.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Source file paths are now correctly passed to transformation plugins. Previously, file paths were always omitted during transformations, which could impact error reporting and plugin functionality.

* **Tests**
  * Added comprehensive test coverage for source file path handling in transformations to verify that file paths are properly preserved and accessible through the transformation pipeline.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unjs/jiti/pull/443?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->