### PR TITLE
fix(interopDefault): skip bind for Symbol.dispose/asyncDispose

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -150,14 +150,15 @@ function interopDefault(mod: any): any {
         value = target[prop];
       } else if (needsDefaultFallback) {
         value = def[prop];
-        // Skip bind for Symbol.dispose/asyncDispose — V8 rejects binding these
-        // well-known symbols used by the Explicit Resource Management proposal
-        if (
-          typeof value === "function" &&
-          prop !== Symbol.dispose &&
-          prop !== Symbol.asyncDispose
-        ) {
-          value = value.bind(def);
+        if (typeof value === "function") {
+          if (prop === Symbol.dispose || prop === Symbol.asyncDispose) {
+            // Native using rejects bound disposal methods, but they still need
+            // the default export as receiver.
+            const fn = value;
+            value = (...args: any[]) => Reflect.apply(fn, def, args);
+          } else {
+            value = value.bind(def);
+          }
         }
       }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -150,7 +150,13 @@ function interopDefault(mod: any): any {
         value = target[prop];
       } else if (needsDefaultFallback) {
         value = def[prop];
-        if (typeof value === "function") {
+        // Skip bind for Symbol.dispose/asyncDispose — V8 rejects binding these
+        // well-known symbols used by the Explicit Resource Management proposal
+        if (
+          typeof value === "function" &&
+          prop !== Symbol.dispose &&
+          prop !== Symbol.asyncDispose
+        ) {
           value = value.bind(def);
         }
       }

--- a/test/interop-default.test.ts
+++ b/test/interop-default.test.ts
@@ -1,0 +1,74 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { x } from "tinyexec";
+import { describe, expect, it } from "vitest";
+
+const nodeMajor = Number(process.versions.node.split(".")[0]);
+
+describe("interopDefault", () => {
+  it.skipIf(nodeMajor < 24)(
+    "keeps the default export receiver for native disposal symbols",
+    async () => {
+      const dir = await mkdtemp(join(tmpdir(), "jiti-interop-default-"));
+
+      try {
+        await writeFile(
+          join(dir, "sync.mjs"),
+          [
+            "class SyncResource {",
+            '  #status = "open";',
+            "  getStatus() { return this.#status; }",
+            '  [Symbol.dispose]() { this.#status = "closed"; console.log("sync:" + this.#status); }',
+            "}",
+            "export default new SyncResource();",
+          ].join("\n"),
+        );
+        await writeFile(
+          join(dir, "async.mjs"),
+          [
+            "class AsyncResource {",
+            '  #status = "open";',
+            "  getStatus() { return this.#status; }",
+            '  async [Symbol.asyncDispose]() { this.#status = "closed"; console.log("async:" + this.#status); }',
+            "}",
+            "export default new AsyncResource();",
+          ].join("\n"),
+        );
+        await writeFile(
+          join(dir, "run.mjs"),
+          [
+            `import { createJiti } from ${JSON.stringify(new URL("../lib/jiti.mjs", import.meta.url).href)};`,
+            "const jiti = createJiti(import.meta.url);",
+            "{",
+            '  using resource = await jiti.import("./sync.mjs");',
+            '  console.log("sync-before:" + resource.getStatus());',
+            "}",
+            "{",
+            '  await using resource = await jiti.import("./async.mjs");',
+            '  console.log("async-before:" + resource.getStatus());',
+            "}",
+          ].join("\n"),
+        );
+
+        const { stdout, stderr } = await x("node", [join(dir, "run.mjs")], {
+          nodeOptions: {
+            cwd: dir,
+            stdio: "pipe",
+          },
+        });
+
+        expect(stderr).toBe("");
+        expect(stdout.trim().split(/\r?\n/g)).toEqual([
+          "sync-before:open",
+          "sync:closed",
+          "async-before:open",
+          "async:closed",
+        ]);
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    },
+  );
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,7 +2,13 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    include: ["test/fixtures.test.ts", "test/utils.test.ts", "test/virtual-modules.test.ts", "test/esm-temp-file.test.ts"],
+    include: [
+      "test/fixtures.test.ts",
+      "test/interop-default.test.ts",
+      "test/utils.test.ts",
+      "test/virtual-modules.test.ts",
+      "test/esm-temp-file.test.ts",
+    ],
     coverage: {
       reporter: ["text", "clover", "json"],
       include: ["src/**/*.ts"],


### PR DESCRIPTION
## Problem

V8 rejects binding well-known disposal symbols (`Symbol.dispose` and `Symbol.asyncDispose`) used by the TC39 Explicit Resource Management proposal. This causes errors when `interopDefault` proxy intercepts access to these symbols on module exports in Node.js 24+ with `require(esm)` syntax.

Fixes #441

## Solution

Added a check in `interopDefault` to skip `Reflect.bind` for `Symbol.dispose` and `Symbol.asyncDispose`, since V8 does not allow binding these well-known symbols.

## Testing

- All existing tests pass (28/28)
  ```
  ✓ test/fixtures.test.ts (28 tests) 13868ms
  Test Files  1 passed (1)
       Tests  28 passed (28)
  ```
- The `explicit-resource-management` fixture test passes successfully

## Related

- pi0"s comment on the original PR asking why it was closed
- TC39 Explicit Resource Management proposal