### PR TITLE
fix: throw when default import is expected but missing

### DIFF
--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -47,6 +47,9 @@ export interface Jiti extends NodeRequire {
    *
    * If you need the default export of module, you can use
    * `jiti.import(id, { default: true })` as shortcut to `mod?.default ?? mod`.
+   *
+   * When using `{ default: true }`, jiti throws if the module does not
+   * provide a default export.
    */
   import<T = unknown>(
     id: string,
@@ -376,6 +379,10 @@ export type EvalModuleOptions = Partial<{
    */
   async: boolean;
   forceTranspile: boolean;
+  /**
+   * @default true
+   */
+  interop?: boolean;
 }>;
 
 export interface TransformOptions {

--- a/src/eval.ts
+++ b/src/eval.ts
@@ -200,7 +200,10 @@ export function evalModule(
     mod.loaded = true;
 
     // interopDefault
-    const _exports = jitiInteropDefault(ctx, mod.exports);
+    const _exports =
+      evalOptions.interop === false
+        ? mod.exports
+        : jitiInteropDefault(ctx, mod.exports);
 
     // Return exports
     return _exports;

--- a/src/jiti.ts
+++ b/src/jiti.ts
@@ -12,7 +12,13 @@ import { join, dirname } from "pathe";
 import escapeStringRegexp from "escape-string-regexp";
 import { normalizeAliases } from "pathe/utils";
 import pkg from "../package.json";
-import { debug, isDir } from "./utils";
+import {
+  debug,
+  isDir,
+  hasDefaultExport,
+  createMissingDefaultExportError,
+  jitiInteropDefault,
+} from "./utils";
 import { resolveJitiOptions } from "./options";
 import { jitiResolve } from "./resolve";
 import { evalModule } from "./eval";
@@ -167,8 +173,20 @@ export default function createJiti(
         id: string,
         opts?: JitiResolveOptions & { default?: true },
       ): Promise<T> {
+        if (opts?.default) {
+          const mod = await jitiRequire(ctx, id, {
+            ...opts,
+            async: true,
+            interop: false,
+          });
+          if (!hasDefaultExport(mod)) {
+            throw createMissingDefaultExportError(id);
+          }
+          const interoped = jitiInteropDefault(ctx, mod);
+          return (interoped?.default ?? interoped) as T;
+        }
         const mod = await jitiRequire(ctx, id, { ...opts, async: true });
-        return opts?.default ? (mod?.default ?? mod) : mod;
+        return mod as T;
       },
       esmResolve(id: string, opts?: string | JitiResolveOptions): string {
         if (typeof opts === "string") {

--- a/src/require.ts
+++ b/src/require.ts
@@ -3,7 +3,7 @@ import { readFileSync } from "node:fs";
 import { builtinModules } from "node:module";
 import { fileURLToPath } from "node:url";
 import { extname } from "pathe";
-import { jitiInteropDefault, normalizeWindowsImportId } from "./utils";
+import { applyJitiInterop, normalizeWindowsImportId } from "./utils";
 import { debug } from "./utils";
 import { jitiResolve } from "./resolve";
 import { evalModule } from "./eval";
@@ -11,13 +11,13 @@ import { evalModule } from "./eval";
 export function jitiRequire(
   ctx: Context,
   id: string,
-  opts: JitiResolveOptions & { async: boolean },
+  opts: JitiResolveOptions & { async: boolean; interop?: boolean },
 ) {
   const cache = ctx.parentCache || {};
 
   // Check for node:, file:, and data: protocols
   if (id.startsWith("node:")) {
-    return nativeImportOrRequire(ctx, id, opts.async);
+    return nativeImportOrRequire(ctx, id, opts.async, opts.interop);
   } else if (id.startsWith("file:")) {
     id = fileURLToPath(id);
   } else if (id.startsWith("data:")) {
@@ -27,12 +27,12 @@ export function jitiRequire(
       );
     }
     debug(ctx, "[native]", "[data]", "[import]", id);
-    return nativeImportOrRequire(ctx, id, true);
+    return nativeImportOrRequire(ctx, id, true, opts.interop);
   }
 
   // Check for builtin node module like fs
   if (builtinModules.includes(id) || id === ".pnp.js" /* #24 */) {
-    return nativeImportOrRequire(ctx, id, opts.async);
+    return nativeImportOrRequire(ctx, id, opts.async, opts.interop);
   }
 
   // Check for virtual modules (e.g., bundled modules in compiled Bun binaries)
@@ -40,8 +40,8 @@ export function jitiRequire(
     debug(ctx, "[virtual]", id);
     const mod = ctx.opts.virtualModules[id];
     return opts.async
-      ? Promise.resolve(jitiInteropDefault(ctx, mod))
-      : jitiInteropDefault(ctx, mod);
+      ? Promise.resolve(applyJitiInterop(ctx, mod, opts.interop ?? true))
+      : applyJitiInterop(ctx, mod, opts.interop ?? true);
   }
 
   // Experimental Bun support
@@ -64,7 +64,7 @@ export function jitiRequire(
             if (ctx.opts.moduleCache === false) {
               delete ctx.nativeRequire.cache[id];
             }
-            return jitiInteropDefault(ctx, m);
+            return applyJitiInterop(ctx, m, opts.interop ?? true);
           })
           .catch((error) => {
             debug(
@@ -84,7 +84,7 @@ export function jitiRequire(
         if (ctx.opts.moduleCache === false) {
           delete ctx.nativeRequire.cache[id];
         }
-        return jitiInteropDefault(ctx, _mod);
+        return applyJitiInterop(ctx, _mod, opts.interop ?? true);
       }
     } catch (error: any) {
       debug(
@@ -124,23 +124,27 @@ export function jitiRequire(
       opts.async ? "[import]" : "[require]",
       filename,
     );
-    return nativeImportOrRequire(ctx, filename, opts.async);
+    return nativeImportOrRequire(ctx, filename, opts.async, opts.interop);
   }
 
   // Force native modules
   if (ctx.isNativeRe.test(filename)) {
     debug(ctx, "[native]", opts.async ? "[import]" : "[require]", filename);
-    return nativeImportOrRequire(ctx, filename, opts.async);
+    return nativeImportOrRequire(ctx, filename, opts.async, opts.interop);
   }
 
   // Check for runtime cache
   if (cache[filename]) {
-    return jitiInteropDefault(ctx, cache[filename]?.exports);
+    return applyJitiInterop(
+      ctx,
+      cache[filename]?.exports,
+      opts.interop ?? true,
+    );
   }
   if (ctx.opts.moduleCache) {
     const cacheEntry = ctx.nativeRequire.cache[filename];
     if (cacheEntry?.loaded) {
-      return jitiInteropDefault(ctx, cacheEntry.exports);
+      return applyJitiInterop(ctx, cacheEntry.exports, opts.interop ?? true);
     }
   }
 
@@ -154,6 +158,7 @@ export function jitiRequire(
     ext,
     cache,
     async: opts.async,
+    interop: opts.interop,
   });
 }
 
@@ -161,10 +166,11 @@ export function nativeImportOrRequire(
   ctx: Context,
   id: string,
   async?: boolean,
+  interop?: boolean,
 ) {
   return async && ctx.nativeImport
     ? ctx
         .nativeImport(normalizeWindowsImportId(id))
-        .then((m: any) => jitiInteropDefault(ctx, m))
-    : jitiInteropDefault(ctx, ctx.nativeRequire(id));
+        .then((m: any) => applyJitiInterop(ctx, m, interop ?? true))
+    : applyJitiInterop(ctx, ctx.nativeRequire(id), interop ?? true);
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -102,6 +102,35 @@ export function jitiInteropDefault(ctx: Context, mod: any) {
   return ctx.opts.interopDefault ? interopDefault(mod) : mod;
 }
 
+export function applyJitiInterop(ctx: Context, mod: any, interop = true) {
+  return interop ? jitiInteropDefault(ctx, mod) : mod;
+}
+
+export function hasDefaultExport(exports: unknown): boolean {
+  if (exports === null || exports === undefined) {
+    return false;
+  }
+
+  const type = typeof exports;
+  if (type !== "object" && type !== "function") {
+    return false;
+  }
+
+  if (type === "function") {
+    return true;
+  }
+
+  if ((exports as Record<string, unknown>).__esModule === true) {
+    return Object.prototype.hasOwnProperty.call(exports, "default");
+  }
+
+  return true;
+}
+
+export function createMissingDefaultExportError(id: string): Error {
+  return new Error(`Module "${id}" does not provide a default export`);
+}
+
 function interopDefault(mod: any): any {
   const modType = typeof mod;
   if (mod === null || (modType !== "object" && modType !== "function")) {

--- a/test/__snapshots__/fixtures.test.ts.snap
+++ b/test/__snapshots__/fixtures.test.ts.snap
@@ -8,6 +8,8 @@ exports[`fixtures > cjs-interop > stdout 1`] = `"CJS function default interop te
 
 exports[`fixtures > data-uri > stdout 1`] = `""`;
 
+exports[`fixtures > default-export-missing > stdout 1`] = `"Module "./named-only.ts" does not provide a default export"`;
+
 exports[`fixtures > deps > stdout 1`] = `
 "npm:config: true
 npm:defu {}

--- a/test/fixtures/default-export-missing/index.mjs
+++ b/test/fixtures/default-export-missing/index.mjs
@@ -1,0 +1,10 @@
+import { createJiti } from "../../../lib/jiti.cjs";
+
+const jiti = createJiti(import.meta.url);
+
+try {
+  await jiti.import("./named-only.ts", { default: true });
+  console.log("missing default export test failed");
+} catch (error) {
+  console.log(String(error.message));
+}

--- a/test/fixtures/default-export-missing/named-only.ts
+++ b/test/fixtures/default-export-missing/named-only.ts
@@ -1,0 +1,1 @@
+export const foo = "bar";

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, beforeEach, it, expect, vi } from "vitest";
 import { isWindows } from "std-env";
 import { getCacheDir } from "../src/cache";
+import { hasDefaultExport } from "../src/utils";
 
 describe("utils", () => {
   describe.skipIf(isWindows)("getCacheDir", () => {
@@ -38,6 +39,24 @@ describe("utils", () => {
       vi.stubEnv("JITI_RESPECT_TMPDIR_ENV", "true");
 
       expect(getCacheDir({} as any)).toBe("/cwd/jiti");
+    });
+  });
+
+  describe("hasDefaultExport", () => {
+    it("detects explicit default exports", () => {
+      expect(hasDefaultExport({ __esModule: true, default: () => {} })).toBe(
+        true,
+      );
+      expect(hasDefaultExport({ __esModule: true, default: undefined })).toBe(
+        true,
+      );
+      expect(hasDefaultExport(() => {})).toBe(true);
+      expect(hasDefaultExport({ foo: "bar" })).toBe(true);
+    });
+
+    it("detects missing default exports", () => {
+      expect(hasDefaultExport({ __esModule: true, foo: "bar" })).toBe(false);
+      expect(hasDefaultExport(undefined)).toBe(false);
     });
   });
 });


### PR DESCRIPTION
## Summary

- When `jiti.import(id, { default: true })` is used, jiti now validates that the loaded module actually provides a default export before applying interop
- Throws a clear error: `Module "<id>" does not provide a default export`
- Adds `interop: false` option to internal require/eval paths so validation runs on raw exports

Fixes #434

## Test plan

- [x] Added `default-export-missing` fixture covering named-only module with `{ default: true }`
- [x] Added unit tests for `hasDefaultExport`
- [x] `pnpm build` passes
- [x] `pnpm lint` passes
- [x] Related vitest fixtures pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `interop` option to control default export handling behavior.

* **Documentation**
  * Clarified that importing with default export requirement throws when the module doesn't provide a default export.

* **Improvements**
  * Enhanced error handling to throw an error when attempting to import a missing default export.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unjs/jiti/pull/450?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->