### PR TITLE
fix(tsconfig): resolve paths from referenced projects in solution-style tsconfigs

### DIFF
--- a/src/jiti.ts
+++ b/src/jiti.ts
@@ -6,9 +6,10 @@ import type {
   EvalModuleOptions,
   JitiResolveOptions,
 } from "./types";
+import { existsSync, statSync } from "node:fs";
 import { platform } from "node:os";
 import { fileURLToPath, pathToFileURL } from "mlly";
-import { join, dirname } from "pathe";
+import { join, dirname, basename, resolve } from "pathe";
 import escapeStringRegexp from "escape-string-regexp";
 import { normalizeAliases } from "pathe/utils";
 import pkg from "../package.json";
@@ -21,6 +22,62 @@ import { jitiRequire } from "./require";
 import { prepareCacheDir } from "./cache";
 
 const isWindows = platform() === "win32";
+
+/**
+ * Create a paths matcher from the referenced projects of a solution-style
+ * tsconfig (issue #440). The root config only contains `references` while
+ * `paths` live in the referenced projects (e.g. `tsconfig.node.json`).
+ *
+ * Each referenced project gets its own matcher (paths are relative to the
+ * config that declares them) and the candidates are concatenated.
+ */
+type GetTsconfig = (typeof import("get-tsconfig"))["getTsconfig"];
+type TsConfigResult = NonNullable<ReturnType<GetTsconfig>>;
+
+function createReferencedPathsMatcher(
+  rootTsconfig: TsConfigResult,
+  getTsconfig: GetTsconfig,
+  createPathsMatcher: (typeof import("get-tsconfig"))["createPathsMatcher"],
+): ((specifier: string) => string[]) | undefined {
+  const matchers: Array<(specifier: string) => string[]> = [];
+  const visited = new Set<string>([resolve(rootTsconfig.path)]);
+  const pending: Array<{ ref: string; baseDir: string }> = (
+    rootTsconfig.config.references || []
+  ).map((ref) => ({ ref: ref.path!, baseDir: dirname(rootTsconfig.path) }));
+
+  while (pending.length > 0) {
+    const { ref, baseDir } = pending.shift()!;
+    const resolved = resolve(baseDir, ref);
+    const stat = existsSync(resolved) ? statSync(resolved) : undefined;
+    const configFile = stat?.isDirectory()
+      ? join(resolved, "tsconfig.json")
+      : resolved;
+    if (visited.has(configFile)) {
+      continue;
+    }
+    visited.add(configFile);
+    const tsconfig = getTsconfig(dirname(configFile), basename(configFile));
+    if (!tsconfig) {
+      continue;
+    }
+    if (tsconfig.config.compilerOptions?.paths) {
+      const matcher = createPathsMatcher(tsconfig);
+      if (matcher) {
+        matchers.push(matcher);
+      }
+    }
+    for (const nested of tsconfig.config.references || []) {
+      if (nested.path) {
+        pending.push({ ref: nested.path, baseDir: dirname(tsconfig.path) });
+      }
+    }
+  }
+
+  if (matchers.length === 0) {
+    return undefined;
+  }
+  return (specifier) => matchers.flatMap((matcher) => matcher(specifier));
+}
 
 export default function createJiti(
   filename: string,
@@ -61,6 +118,15 @@ export default function createJiti(
     const tsconfig = getTsconfig(searchPath);
     if (tsconfig) {
       resolveTsConfigPaths = createPathsMatcher(tsconfig)!;
+      // Solution-style tsconfigs can keep `paths` in referenced projects
+      // instead of the root config (#440)
+      if (!resolveTsConfigPaths) {
+        resolveTsConfigPaths = createReferencedPathsMatcher(
+          tsconfig,
+          getTsconfig,
+          createPathsMatcher,
+        );
+      }
     }
   }
 

--- a/test/__snapshots__/fixtures.test.ts.snap
+++ b/test/__snapshots__/fixtures.test.ts.snap
@@ -149,6 +149,8 @@ exports[`fixtures > top-level-await > stdout 1`] = `"async value works from sub 
 
 exports[`fixtures > tsconfig-paths > stdout 1`] = `"jiti-tsconfig-paths-test"`;
 exports[`fixtures > tsconfig-references > stdout 1`] = `"meaning of life: 42"`;
+exports[`fixtures > tsconfig-references-cycle > stdout 1`] = `"cycle: 42"`;
+exports[`fixtures > tsconfig-references-nested > stdout 1`] = `"nested: 42"`;
 
 exports[`fixtures > typescript > stdout 1`] = `
 "Decorator metadata keys: design:type

--- a/test/__snapshots__/fixtures.test.ts.snap
+++ b/test/__snapshots__/fixtures.test.ts.snap
@@ -148,6 +148,7 @@ Logical nullish assignment: 50 20"
 exports[`fixtures > top-level-await > stdout 1`] = `"async value works from sub module"`;
 
 exports[`fixtures > tsconfig-paths > stdout 1`] = `"jiti-tsconfig-paths-test"`;
+exports[`fixtures > tsconfig-references > stdout 1`] = `"meaning of life: 42"`;
 
 exports[`fixtures > typescript > stdout 1`] = `
 "Decorator metadata keys: design:type

--- a/test/fixtures/tsconfig-references-cycle/a/tsconfig.json
+++ b/test/fixtures/tsconfig-references-cycle/a/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "files": [],
+  "references": [{ "path": "../b" }]
+}

--- a/test/fixtures/tsconfig-references-cycle/b/src/test.ts
+++ b/test/fixtures/tsconfig-references-cycle/b/src/test.ts
@@ -1,0 +1,1 @@
+export const meaningOfLife = 42;

--- a/test/fixtures/tsconfig-references-cycle/b/tsconfig.json
+++ b/test/fixtures/tsconfig-references-cycle/b/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "paths": {
+      "@b/*": ["./src/*"]
+    }
+  },
+  "include": ["src"],
+  "references": [{ "path": "../a" }]
+}

--- a/test/fixtures/tsconfig-references-cycle/index.mjs
+++ b/test/fixtures/tsconfig-references-cycle/index.mjs
@@ -1,0 +1,5 @@
+import { createJiti } from "../../../lib/jiti.mjs";
+
+const jiti = createJiti(import.meta.url, { tsconfigPaths: true });
+
+jiti("./main.ts");

--- a/test/fixtures/tsconfig-references-cycle/main.ts
+++ b/test/fixtures/tsconfig-references-cycle/main.ts
@@ -1,0 +1,3 @@
+import { meaningOfLife } from "@b/test";
+
+console.log("cycle:", meaningOfLife);

--- a/test/fixtures/tsconfig-references-cycle/tsconfig.json
+++ b/test/fixtures/tsconfig-references-cycle/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "files": [],
+  "references": [{ "path": "./a" }]
+}

--- a/test/fixtures/tsconfig-references-nested/index.mjs
+++ b/test/fixtures/tsconfig-references-nested/index.mjs
@@ -1,0 +1,5 @@
+import { createJiti } from "../../../lib/jiti.mjs";
+
+const jiti = createJiti(import.meta.url, { tsconfigPaths: true });
+
+jiti("./main.ts");

--- a/test/fixtures/tsconfig-references-nested/main.ts
+++ b/test/fixtures/tsconfig-references-nested/main.ts
@@ -1,0 +1,3 @@
+import { meaningOfLife } from "@lib/test";
+
+console.log("nested:", meaningOfLife);

--- a/test/fixtures/tsconfig-references-nested/packages/app/tsconfig.json
+++ b/test/fixtures/tsconfig-references-nested/packages/app/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "files": [],
+  "references": [{ "path": "../lib" }]
+}

--- a/test/fixtures/tsconfig-references-nested/packages/lib/src/test.ts
+++ b/test/fixtures/tsconfig-references-nested/packages/lib/src/test.ts
@@ -1,0 +1,1 @@
+export const meaningOfLife = 42;

--- a/test/fixtures/tsconfig-references-nested/packages/lib/tsconfig.json
+++ b/test/fixtures/tsconfig-references-nested/packages/lib/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "paths": {
+      "@lib/*": ["./src/*"]
+    }
+  },
+  "include": ["src"]
+}

--- a/test/fixtures/tsconfig-references-nested/tsconfig.json
+++ b/test/fixtures/tsconfig-references-nested/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "files": [],
+  "references": [{ "path": "./packages/app" }]
+}

--- a/test/fixtures/tsconfig-references/index.mjs
+++ b/test/fixtures/tsconfig-references/index.mjs
@@ -1,0 +1,5 @@
+import { createJiti } from "../../../lib/jiti.mjs";
+
+const jiti = createJiti(import.meta.url, { tsconfigPaths: true });
+
+jiti("./main.ts");

--- a/test/fixtures/tsconfig-references/main.ts
+++ b/test/fixtures/tsconfig-references/main.ts
@@ -1,0 +1,3 @@
+import { meaningOfLife } from "@/test";
+
+console.log("meaning of life:", meaningOfLife);

--- a/test/fixtures/tsconfig-references/src/test.ts
+++ b/test/fixtures/tsconfig-references/src/test.ts
@@ -1,0 +1,1 @@
+export const meaningOfLife = 42;

--- a/test/fixtures/tsconfig-references/tsconfig.json
+++ b/test/fixtures/tsconfig-references/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "files": [],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/test/fixtures/tsconfig-references/tsconfig.node.json
+++ b/test/fixtures/tsconfig-references/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["src", "main.ts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,5 +17,5 @@
     "declaration": false
   },
   "include": ["src", "lib", "test"],
-  "exclude": ["test/fixtures/error-parse/index.ts", "test/fixtures/tsconfig-references/main.ts"]
+  "exclude": ["test/fixtures/error-parse/index.ts", "test/fixtures/tsconfig-references/main.ts", "test/fixtures/tsconfig-references-nested/main.ts", "test/fixtures/tsconfig-references-cycle/main.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,5 +17,5 @@
     "declaration": false
   },
   "include": ["src", "lib", "test"],
-  "exclude": ["test/fixtures/error-parse/index.ts"]
+  "exclude": ["test/fixtures/error-parse/index.ts", "test/fixtures/tsconfig-references/main.ts"]
 }


### PR DESCRIPTION
### 🔧 Fix: resolve `tsconfigPaths` from referenced projects in solution-style tsconfigs

Fixes #440 — `tsconfigPaths` does not behave like `tsc -b` when a solution-style `tsconfig.json` keeps its `paths` in a referenced project (e.g. `tsconfig.node.json`).

**Repro:** a root `tsconfig.json` containing only `"files": []` + `"references": [{ "path": "./tsconfig.node.json" }]`, with `paths: { "@/*": ["./src/*"] }` defined in `tsconfig.node.json`. `tsc -b` resolves `@/test`; `jiti` with `tsconfigPaths: true` fails with `MODULE_NOT_FOUND: Cannot find module '@/test'` because `getTsconfig()` returns the root config, which has no `paths`, and `createPathsMatcher()` only looks at the config that was found.

**Fix (`src/jiti.ts`):** when the found tsconfig produces no paths matcher, `createReferencedPathsMatcher()` walks its `references` (breadth-first, cycle-safe, with the base directory tracked per project so nested references in subdirectories resolve relative to the config that declares them) and composes one `createPathsMatcher()` per referenced project that declares `paths`. The fallback only activates when the root config has no `paths` — existing behavior is untouched.

### Test (red → green, executed)

New fixture `test/fixtures/tsconfig-references/` reproduces the issue: solution-style root tsconfig, `@/*` alias in the referenced project, `main.ts` imports `@/test`.

| State | Commit | Result |
|---|---|---|
| Red | `c567045` (fixture only) | `Cannot find module '@/test'` — the exact error from #440 |
| Green | `43cc2e8` (fix) | fixture passes, snapshot `"meaning of life: 42"` |

The `main.ts` fixture is added to the `tsconfig.json` `exclude` (same pattern the repo already uses for `test/fixtures/error-parse/index.ts`), since the alias cannot resolve at type level in the root project — that is precisely the bug.

### Checks

- `pnpm build` (rspack) ✅
- `pnpm lint` (eslint + prettier) ✅
- `pnpm test:types` (tsgo --noEmit) ✅
- `pnpm vitest run` — 36/36 passed, 4 skipped, no regressions ✅


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for resolving TypeScript path aliases defined in referenced project configurations.
  - Alias resolution now works when the root TypeScript configuration delegates settings to another configuration.
  - Supports nested project references and safely handles circular references.

- **Bug Fixes**
  - Improved module loading for projects using solution-style TypeScript configurations.

- **Tests**
  - Added coverage for path alias resolution across referenced, nested, and circular TypeScript configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->