### PR TITLE
fix(interop): don't cache accessor properties in interopDefault proxy

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -147,6 +147,13 @@ function interopDefault(mod: any): any {
           value = def;
         }
       } else if (prop in target) {
+        const desc = Object.getOwnPropertyDescriptor(target, prop);
+        if (desc && (desc.get || desc.set)) {
+          // Live bindings (e.g. mutable ESM exports downleveled to getters
+          // by Babel's CJS transform) must be re-read on every access, not
+          // memoized, or mutations after the first read go unobserved.
+          return Reflect.get(target, prop);
+        }
         value = target[prop];
       } else if (needsDefaultFallback) {
         value = def[prop];

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -7,7 +7,7 @@ describe("utils", () => {
   describe("jitiInteropDefault", () => {
     const ctx = { opts: { interopDefault: true } } as any;
 
-    it("re-reads live-binding (mutable) named exports instead of returning a cached stale value (regression for #421)", () => {
+    it("re-reads live-binding (mutable) named exports instead of returning a cached stale value (regression for #457)", () => {
       // Mirrors what jiti's own ESM->CJS transform (src/plugins/transform-module,
       // based on @babel/plugin-transform-modules-commonjs) emits for:
       //   export let counter = 1;

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,8 +1,38 @@
 import { afterEach, describe, beforeEach, it, expect, vi } from "vitest";
 import { isWindows } from "std-env";
 import { getCacheDir } from "../src/cache";
+import { jitiInteropDefault } from "../src/utils";
 
 describe("utils", () => {
+  describe("jitiInteropDefault", () => {
+    const ctx = { opts: { interopDefault: true } } as any;
+
+    it("re-reads live-binding (mutable) named exports instead of returning a cached stale value (regression for #421)", () => {
+      // Mirrors what jiti's own ESM->CJS transform (src/plugins/transform-module,
+      // based on @babel/plugin-transform-modules-commonjs) emits for:
+      //   export let counter = 1;
+      //   export function increment() { counter++; }
+      // Babel defines mutable exports as *live getters* on `exports` so every
+      // read reflects the current value - that's how ESM live bindings survive
+      // being downleveled to CommonJS.
+      let counter = 1;
+      const mod: any = { __esModule: true };
+      Object.defineProperty(mod, "counter", {
+        enumerable: true,
+        get: () => counter,
+      });
+      mod.increment = () => {
+        counter++;
+      };
+
+      const wrapped = jitiInteropDefault(ctx, mod);
+
+      expect(wrapped.counter).toBe(1);
+      wrapped.increment();
+      expect(wrapped.counter).toBe(2);
+    });
+  });
+
   describe.skipIf(isWindows)("getCacheDir", () => {
     const cwd = "/cwd";
     const notCwd = `${cwd}__NOT__`;


### PR DESCRIPTION
Fixes #457
  
  ## Root cause
  
  `a467d31` (#421) added a `Map`-based cache inside the `Proxy` returned by `interopDefault()` in `src/utils.ts`,
  memoizing every property read permanently. That breaks live bindings: when jiti's own Babel CJS transform
  downlevels a mutable ESM export (`export let x`) into a getter on `exports`, the *first* read locks in that value
  forever, even after the underlying binding changes.

  ## Fix

  Only skip the cache for accessor properties (`desc.get`/`desc.set`), falling through to a fresh `Reflect.get` for
  those. Plain data properties (the common case for ordinary CJS `module.exports`) are still memoized, so most of
  #421's perf win is preserved — only getter-backed live bindings pay the always-fresh-read cost, since they can't
  be soundly memoized by property name.
  
  ## Repro (before fix)
  
  first read: 1
  after increment(): 1   // stale — should be 2

  After the fix:

  first read: 1
  after increment(): 2

  ## Test
  
  Added a regression test in `test/utils.test.ts` under `describe("jitiInteropDefault")`: wraps a mock module
  shaped like jiti's real Babel-CJS output (a live getter + a mutator) with the real exported `jitiInteropDefault`,
  asserting the read value updates after mutation. Fails red on `main`, passes after this fix.

  ## Local test gate
  
  - `pnpm lint` — clean (one pre-existing, unrelated formatting warning in `serialize-type.ts`, present on `main`
  before this branch)
  - `pnpm test:types` — pass
  - `pnpm vitest run --coverage` — pass (40/40)
  - `pnpm test:node-register` — pass (29/29)
  - `test:bun` / `test:native:bun` / `test:native:deno` — skipped locally (bun/deno not installed on my machine);
  leaving these for CI to cover.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved module interoperability so getter-based values always reflect their latest updates instead of returning stale cached values.
  - Preserved live updates for mutable named exports in wrapped modules, ensuring consumers receive current values after changes.

- **Tests**
  - Added regression coverage to verify that updated getter-backed exports remain synchronized and continue reflecting changes correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->