### PR TITLE
fix(babel): allow Stage 3 decorator transforms

### DIFF
--- a/src/babel.ts
+++ b/src/babel.ts
@@ -42,6 +42,12 @@ export default function transform(opts: TransformOptions): TransformResult {
         normalizeProposalDecoratorsPlugin(plugin),
       )
     : [];
+  const customDecoratorsPlugins = customPlugins.filter((plugin) =>
+    isProposalDecoratorsPlugin(plugin),
+  );
+  const otherCustomPlugins = customPlugins.filter(
+    (plugin) => !isProposalDecoratorsPlugin(plugin),
+  );
   const _opts: BabelTransformOptions & { plugins: PluginItem[] } = {
     babelrc: false,
     configFile: false,
@@ -85,17 +91,22 @@ export default function transform(opts: TransformOptions): TransformResult {
       },
     ]);
     // `unshift` because these plugin must come before `@babel/plugin-syntax-class-properties`
+    // A decorator transform must also come before `@babel/plugin-transform-typescript`,
+    // so a caller-provided one takes the same slot as the legacy default instead of
+    // being appended after it.
     _opts.plugins.unshift(
       [transformTypeScriptMetaPlugin],
-      ...(customPlugins.some((plugin) => isProposalDecoratorsPlugin(plugin))
-        ? []
+      ...(customDecoratorsPlugins.length > 0
+        ? customDecoratorsPlugins
         : ([[proposalDecoratorsPlugin, { legacy: true }]] as PluginItem[])),
     );
     _opts.plugins.push(parameterDecoratorPlugin, syntaxImportAssertionsPlugin);
   }
 
-  if (customPlugins.length > 0) {
-    _opts.plugins.push(...customPlugins);
+  // When `opts.ts` is set, decorator plugins have already been unshifted above.
+  const remainingCustomPlugins = opts.ts ? otherCustomPlugins : customPlugins;
+  if (remainingCustomPlugins.length > 0) {
+    _opts.plugins.push(...remainingCustomPlugins);
   }
 
   try {

--- a/src/babel.ts
+++ b/src/babel.ts
@@ -19,7 +19,29 @@ import importMetaPathsPlugin from "./plugins/import-meta-paths";
 import transformModulesPlugin from "./plugins/transform-module";
 import type { TransformOptions, TransformResult } from "./types";
 
+function isProposalDecoratorsPlugin(plugin: PluginItem): boolean {
+  const target = Array.isArray(plugin) ? plugin[0] : plugin;
+  return (
+    target === proposalDecoratorsPlugin ||
+    target === "@babel/plugin-proposal-decorators"
+  );
+}
+
+function normalizeProposalDecoratorsPlugin(plugin: PluginItem): PluginItem {
+  if (!isProposalDecoratorsPlugin(plugin) || !Array.isArray(plugin)) {
+    return plugin === "@babel/plugin-proposal-decorators"
+      ? proposalDecoratorsPlugin
+      : plugin;
+  }
+  return [proposalDecoratorsPlugin, ...plugin.slice(1)] as PluginItem;
+}
+
 export default function transform(opts: TransformOptions): TransformResult {
+  const customPlugins = Array.isArray(opts.babel?.plugins)
+    ? opts.babel.plugins.map((plugin) =>
+        normalizeProposalDecoratorsPlugin(plugin),
+      )
+    : [];
   const _opts: BabelTransformOptions & { plugins: PluginItem[] } = {
     babelrc: false,
     configFile: false,
@@ -65,13 +87,15 @@ export default function transform(opts: TransformOptions): TransformResult {
     // `unshift` because these plugin must come before `@babel/plugin-syntax-class-properties`
     _opts.plugins.unshift(
       [transformTypeScriptMetaPlugin],
-      [proposalDecoratorsPlugin, { legacy: true }],
+      ...(customPlugins.some((plugin) => isProposalDecoratorsPlugin(plugin))
+        ? []
+        : ([[proposalDecoratorsPlugin, { legacy: true }]] as PluginItem[])),
     );
     _opts.plugins.push(parameterDecoratorPlugin, syntaxImportAssertionsPlugin);
   }
 
-  if (opts.babel && Array.isArray(opts.babel.plugins)) {
-    _opts.plugins?.push(...opts.babel.plugins);
+  if (customPlugins.length > 0) {
+    _opts.plugins.push(...customPlugins);
   }
 
   try {

--- a/test/transform.test.ts
+++ b/test/transform.test.ts
@@ -2,33 +2,72 @@ import proposalDecoratorsPlugin from "@babel/plugin-proposal-decorators";
 import { describe, expect, it } from "vitest";
 import transform from "../src/babel";
 
+const decoratorPluginForms = [
+  proposalDecoratorsPlugin,
+  "@babel/plugin-proposal-decorators",
+] as const;
+
+function evaluate(code: string): Record<string, unknown> {
+  const module = { exports: {} as Record<string, unknown> };
+  new Function("exports", "module", code)(module.exports, module);
+  return module.exports;
+}
+
 describe("transform", () => {
-  it.each([
-    proposalDecoratorsPlugin,
-    "@babel/plugin-proposal-decorators",
-  ] as const)("allows configuring stage 3 decorators with %s", (plugin) => {
-    const result = transform({
-      filename: "decorators.ts",
-      source: `
-        let kind;
-        function decorator(value, context) {
-          kind = context.kind;
-        }
-        @decorator
-        class Example {}
-        export { kind };
-      `,
-      ts: true,
-      babel: {
-        plugins: [[plugin, { version: "2023-11" }]],
-      },
-    });
+  it.each(decoratorPluginForms)(
+    "allows configuring stage 3 decorators with %s",
+    (plugin) => {
+      const result = transform({
+        filename: "decorators.ts",
+        source: `
+          let kind;
+          function decorator(value, context) {
+            kind = context.kind;
+          }
+          @decorator
+          class Example {}
+          export { kind };
+        `,
+        ts: true,
+        babel: {
+          plugins: [[plugin, { version: "2023-11" }]],
+        },
+      });
 
-    expect(result.error).toBeUndefined();
+      expect(result.error).toBeUndefined();
+      expect(evaluate(result.code).kind).toBe("class");
+    },
+  );
 
-    const module = { exports: {} as Record<string, unknown> };
-    new Function("exports", "module", result.code)(module.exports, module);
+  it.each(decoratorPluginForms)(
+    "runs stage 3 decorators before the TypeScript transform with %s",
+    (plugin) => {
+      const result = transform({
+        filename: "decorators.ts",
+        source: `
+          let kind;
+          function decorator(value, context) {
+            kind = context.kind;
+          }
+          class Example {
+            declare id: string;
+            @decorator
+            value: number = 1;
+          }
+          export { kind };
+          export const example = new Example();
+        `,
+        ts: true,
+        babel: {
+          plugins: [[plugin, { version: "2023-11" }]],
+        },
+      });
 
-    expect(module.exports.kind).toBe("class");
-  });
+      expect(result.error).toBeUndefined();
+
+      const exported = evaluate(result.code);
+      expect(exported.kind).toBe("field");
+      expect((exported.example as { value: number }).value).toBe(1);
+    },
+  );
 });

--- a/test/transform.test.ts
+++ b/test/transform.test.ts
@@ -1,0 +1,34 @@
+import proposalDecoratorsPlugin from "@babel/plugin-proposal-decorators";
+import { describe, expect, it } from "vitest";
+import transform from "../src/babel";
+
+describe("transform", () => {
+  it.each([
+    proposalDecoratorsPlugin,
+    "@babel/plugin-proposal-decorators",
+  ] as const)("allows configuring stage 3 decorators with %s", (plugin) => {
+    const result = transform({
+      filename: "decorators.ts",
+      source: `
+        let kind;
+        function decorator(value, context) {
+          kind = context.kind;
+        }
+        @decorator
+        class Example {}
+        export { kind };
+      `,
+      ts: true,
+      babel: {
+        plugins: [[plugin, { version: "2023-11" }]],
+      },
+    });
+
+    expect(result.error).toBeUndefined();
+
+    const module = { exports: {} as Record<string, unknown> };
+    new Function("exports", "module", result.code)(module.exports, module);
+
+    expect(module.exports.kind).toBe("class");
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,7 +2,13 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    include: ["test/fixtures.test.ts", "test/utils.test.ts", "test/virtual-modules.test.ts", "test/esm-temp-file.test.ts"],
+    include: [
+      "test/fixtures.test.ts",
+      "test/utils.test.ts",
+      "test/virtual-modules.test.ts",
+      "test/esm-temp-file.test.ts",
+      "test/transform.test.ts",
+    ],
     coverage: {
       reporter: ["text", "clover", "json"],
       include: ["src/**/*.ts"],


### PR DESCRIPTION
Fixes #381

## What changed

- detect a caller-provided `@babel/plugin-proposal-decorators` configuration and avoid injecting Jiti's legacy decorator transform alongside it
- resolve the package-name form to Jiti's bundled decorator plugin, so both Babel's string and function plugin forms work
- retain the existing legacy decorator behavior when no custom decorator transform is configured
- add regression coverage that executes transformed Stage 3 decorator output and verifies `context.kind`

## Testing

- `pnpm exec eslint src/babel.ts test/transform.test.ts vitest.config.ts`
- `pnpm exec prettier -c src lib test stubs`
- `pnpm test:types`
- `pnpm vitest run --coverage` (37 passed)
- `pnpm rspack`
- Node register/native suites (29 + 15 passed)
- Bun native suite (25 passed)
- Deno native suite (22 passed)

Codex assisted with repository exploration, implementation, tests, and validation. The resulting behavior and diff were reviewed before submission.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring Stage 3 decorators by package name or plugin object.
  * Preserved decorator plugin options during transformation.
  * Decorators now run correctly before TypeScript processing, including decorated fields and field initialization.
* **Bug Fixes**
  * Ensured custom decorator configurations take precedence over legacy defaults.
* **Tests**
  * Expanded coverage for decorator execution, plugin formats, and decorator context handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->