### PR TITLE
fix(cache): walk up to the nearest node_modules for default fsCache

### DIFF
--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,7 +1,7 @@
 import type { Context, TransformOptions } from "./types";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { dirname, join, basename, resolve } from "pathe";
+import { dirname, join, basename } from "pathe";
 import { filename } from "pathe/utils";
 import { debug, isWritable, hash } from "./utils";
 
@@ -69,9 +69,19 @@ export function prepareCacheDir(ctx: Context) {
 }
 
 export function getCacheDir(ctx: Context) {
-  const nmDir = ctx.filename && resolve(ctx.filename, "../node_modules");
-  if (nmDir && existsSync(nmDir)) {
-    return join(nmDir, ".cache/jiti");
+  // Walk up from the instance file so `createJiti(import.meta.url)` resolves
+  // `<pkg>/node_modules/.cache/jiti` rather than `<fileDir>/node_modules`.
+  let dir = ctx.filename ? dirname(ctx.filename) : "";
+  while (dir) {
+    const nmDir = join(dir, "node_modules");
+    if (existsSync(nmDir)) {
+      return join(nmDir, ".cache/jiti");
+    }
+    const parent = dirname(dir);
+    if (parent === dir) {
+      break;
+    }
+    dir = parent;
   }
 
   let _tmpDir = tmpdir();

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,3 +1,6 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "pathe";
 import { afterEach, describe, beforeEach, it, expect, vi } from "vitest";
 import { isWindows } from "std-env";
 import { getCacheDir } from "../src/cache";
@@ -39,5 +42,20 @@ describe("utils", () => {
 
       expect(getCacheDir({} as any)).toBe("/cwd/jiti");
     });
+  });
+
+  it("walks up from a nested file to the nearest node_modules (#459)", () => {
+    const root = mkdtempSync(join(tmpdir(), "jiti-fscache-"));
+    mkdirSync(join(root, "node_modules"));
+    mkdirSync(join(root, "src"), { recursive: true });
+    const filename = join(root, "src", "loader.ts");
+    writeFileSync(filename, "");
+    try {
+      expect(getCacheDir({ filename } as any)).toBe(
+        join(root, "node_modules/.cache/jiti"),
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## Summary

`getCacheDir()` resolved `node_modules` as `resolve(filename, \"../node_modules\")`. For the documented `createJiti(import.meta.url)` usage, `filename` is a source file (for example `src/loader.ts`), so that path is `<pkg>/src/node_modules` rather than `<pkg>/node_modules`. The check fails, and the cache silently falls back to `${tmpdir()}/jiti`.

Walk up from the instance filename and use the nearest existing `node_modules/.cache/jiti`. The tmpdir fallback is unchanged when no `node_modules` directory is found.

Fixes #459

## Test plan

- [x] Added a temp-dir regression test: nested `src/loader.ts` with `node_modules` at the package root resolves to `<pkg>/node_modules/.cache/jiti`
- [x] Existing `getCacheDir` TMPDIR tests still pass (`pnpm vitest run test/utils.test.ts`)
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cache directory detection for files nested within project directories.
  * Cache data is now stored in the nearest applicable project cache location.

* **Tests**
  * Added coverage for locating cache directories from nested file paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
