### PR TITLE
fix: honor moduleCache:false when loading native CJS files

### DIFF
--- a/src/require.ts
+++ b/src/require.ts
@@ -162,6 +162,13 @@ export function nativeImportOrRequire(
   id: string,
   async?: boolean,
 ) {
+  if (ctx.opts.moduleCache === false) {
+    try {
+      delete ctx.nativeRequire.cache[ctx.nativeRequire.resolve(id)];
+    } catch {
+      delete ctx.nativeRequire.cache[id];
+    }
+  }
   return async && ctx.nativeImport
     ? ctx
         .nativeImport(normalizeWindowsImportId(id))

--- a/test/module-cache.test.ts
+++ b/test/module-cache.test.ts
@@ -1,0 +1,36 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { join } from "pathe";
+import { describe, expect, it } from "vitest";
+import createJiti from "../src/jiti";
+
+function makeJiti(filename: string) {
+  return createJiti(
+    filename,
+    { fsCache: false, moduleCache: false },
+    {
+      onError: (error) => {
+        throw error;
+      },
+      nativeImport: (id) => import(id),
+      createRequire,
+    },
+  );
+}
+
+describe("moduleCache: false", () => {
+  it("reloads a changed CJS .js file (#418)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "jiti-module-cache-"));
+    const file = join(dir, "config.js");
+    writeFileSync(file, "module.exports = { n: 1 }\n");
+    const jiti = makeJiti(join(dir, "_index.js"));
+    try {
+      expect(jiti(file)).toMatchObject({ n: 1 });
+      writeFileSync(file, "module.exports = { n: 2 }\n");
+      expect(jiti(file)).toMatchObject({ n: 2 });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,7 +2,13 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    include: ["test/fixtures.test.ts", "test/utils.test.ts", "test/virtual-modules.test.ts", "test/esm-temp-file.test.ts"],
+    include: [
+      "test/fixtures.test.ts",
+      "test/utils.test.ts",
+      "test/virtual-modules.test.ts",
+      "test/esm-temp-file.test.ts",
+      "test/module-cache.test.ts",
+    ],
     coverage: {
       reporter: ["text", "clover", "json"],
       include: ["src/**/*.ts"],


### PR DESCRIPTION
## Summary

With \`moduleCache: false\` (and \`fsCache: false\`), TypeScript configs reload after a file change because they are transpiled and evaluated. Plain CJS \`.js\` files skip transpile and go through \`nativeRequire\`, so Node's \`require.cache\` still returns the first load.

Clear the resolved cache entry before the native require when \`moduleCache\` is disabled. The existing Bun/tryNative path already did this after a native load; the non-transpile Node path did not.

Fixes #418

## Test plan

- [x] Fail-then-pass: write \`config.js\` exporting \`{ n: 1 }\`, load it, rewrite as \`{ n: 2 }\`, load again
- [x] Before the fix the second load stayed \`{ n: 1 }\`; after the fix it is \`{ n: 2 }\`
- [x] \`pnpm vitest run test/module-cache.test.ts\`
