### PR TITLE
fix: keep symbol-keyed fallback methods unbound in interopDefault

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -150,7 +150,12 @@ function interopDefault(mod: any): any {
         value = target[prop];
       } else if (needsDefaultFallback) {
         value = def[prop];
-        if (typeof value === "function") {
+        // Well-known symbol protocols (Symbol.asyncDispose, Symbol.dispose,
+        // Symbol.iterator, ...) are invoked by the engine with the proxy as
+        // receiver, and V8 currently rejects bound functions for the using
+        // declaration protocols (#437). Property access on `this` still
+        // resolves through this trap, so symbol methods stay unbound.
+        if (typeof value === "function" && typeof prop !== "symbol") {
           value = value.bind(def);
         }
       }

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -41,3 +41,47 @@ describe("utils", () => {
     });
   });
 });
+
+describe("interopDefault symbol methods", () => {
+  const { writeFileSync, mkdirSync, rmSync } = require("node:fs");
+  const { tmpdir } = require("node:os");
+  const { resolve } = require("node:path");
+
+  const { createJiti } = require("../lib/jiti.cjs");
+  const dir = resolve(tmpdir(), "jiti-interop-symbol-test");
+
+  beforeEach(() => {
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      resolve(dir, "dep.mjs"),
+      `export const marker = 1;
+export default {
+  regular() { return this; },
+  [Symbol.asyncDispose]: async function () {},
+  [Symbol.dispose]: function () {},
+};
+`,
+    );
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("does not wrap symbol-keyed fallback methods (#437)", async () => {
+    const jiti = createJiti(resolve(dir, "_"), { interopDefault: true });
+    const mod: any = await jiti.import("./dep.mjs");
+    const def = mod.default;
+
+    // Symbol-keyed methods must come through unwrapped: V8 rejects bound
+    // functions for the using declaration protocols, and the engine invokes
+    // them with the proxy as receiver, which resolves through the same trap.
+    expect(mod[Symbol.asyncDispose]).toBe(def[Symbol.asyncDispose]);
+    expect(mod[Symbol.dispose]).toBe(def[Symbol.dispose]);
+
+    // String-keyed fallback methods keep the bind, so extraction preserves
+    // this === default export.
+    const { regular } = mod;
+    expect(regular()).toBe(def);
+  });
+});


### PR DESCRIPTION
Fixes #437.

The report's repro holds, and isolating it narrowed the cause slightly differently than the write-up: on Node 24 (V8 13.x), the engine rejects **any** bound function as a `using`/`await using` dispose method, even on a plain object with no proxy involved:

```js
const fn = async function () {};
await using a = { [Symbol.asyncDispose]: fn.bind(null) };
// TypeError: Symbol(Symbol.asyncDispose) is not a function
await using b = { [Symbol.asyncDispose]: fn }; // works
```

The same rejection applies to sync `using` with `Symbol.dispose`, and to a proxy-wrapped callable. Per the Explicit Resource Management spec, GetMethod only requires IsCallable, and bound functions are callable, so this looks like a V8 spec deviation; I am filing it upstream separately. But jiti users hit it today through `interopDefault`, whose fallback branch binds every function it returns, so a default export with `[Symbol.asyncDispose]` produced the confusing state where `typeof mod[Symbol.asyncDispose] === 'function'` yet `await using mod` throws.

The fix skips the bind for symbol-keyed properties only. That is semantically safe here: the engine invokes protocol methods with the proxy as receiver, and property access on `this` resolves through the same `get` trap, so the method still reaches the default export's state. String-keyed methods keep the bind, so extracted methods (`const { m } = mod`) keep `this === def` exactly as before.

Verified: the issue's repro passes under `lib/jiti.cjs` after the change. Test added asserting symbol-keyed fallback methods come through reference-equal (no wrapper) while string-keyed extraction still binds. `tsgo --noEmit`, eslint, and the fixtures suite (28 passing) are clean; with the source change reverted the new test fails.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved interoperability for modules using symbol-based protocols, including disposal and iteration.
  * Preserved correct behavior for both symbol-keyed and string-keyed methods.

* **Tests**
  * Added coverage validating disposal methods and existing method-binding behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->