### PR TITLE
feat: enable tryNative by default in Deno runtime (#402)

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -25,7 +25,10 @@ export function resolveJitiOptions(userOptions: JitiOptions): JitiOptions {
     alias: _jsonEnv<Record<string, string>>("JITI_ALIAS", {}),
     nativeModules: _jsonEnv<string[]>("JITI_NATIVE_MODULES", []),
     transformModules: _jsonEnv<string[]>("JITI_TRANSFORM_MODULES", []),
-    tryNative: _jsonEnv<boolean>("JITI_TRY_NATIVE", "Bun" in globalThis),
+    tryNative: _jsonEnv<boolean>(
+      "JITI_TRY_NATIVE",
+      "Bun" in globalThis || "Deno" in globalThis,
+    ),
     esmEvalTempFile: _booleanEnv("JITI_ESM_EVAL_TEMP_FILE", false),
     jsx: _booleanEnv("JITI_JSX", false),
     tsconfigPaths: _jsonEnv<boolean | string>(

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -40,4 +40,36 @@ describe("utils", () => {
       expect(getCacheDir({} as any)).toBe("/cwd/jiti");
     });
   });
+
+  describe("resolveJitiOptions", () => {
+    it("enables tryNative when Deno is in globalThis", async () => {
+      const { resolveJitiOptions } = await import("../src/options");
+      (globalThis as any).Deno = {};
+      try {
+        const opts = resolveJitiOptions({});
+        expect(opts.tryNative).toBe(true);
+      } finally {
+        delete (globalThis as any).Deno;
+      }
+    });
+
+    it("enables tryNative when Bun is in globalThis", async () => {
+      const { resolveJitiOptions } = await import("../src/options");
+      (globalThis as any).Bun = {};
+      try {
+        const opts = resolveJitiOptions({});
+        expect(opts.tryNative).toBe(true);
+      } finally {
+        delete (globalThis as any).Bun;
+      }
+    });
+
+    it("disables tryNative by default in standard environment", async () => {
+      const { resolveJitiOptions } = await import("../src/options");
+      delete (globalThis as any).Deno;
+      delete (globalThis as any).Bun;
+      const opts = resolveJitiOptions({});
+      expect(opts.tryNative).toBe(false);
+    });
+  });
 });


### PR DESCRIPTION
Resolves #402.

Per @pi0's suggestion in #402, this enables the `tryNative` option by default in Deno runtime environments (`"Deno" in globalThis`), consistent with the existing Bun default (`"Bun" in globalThis`).

### Changes
- In `src/options.ts`, updated `tryNative` default to check `"Bun" in globalThis || "Deno" in globalThis`.
- Added unit tests in `test/utils.test.ts` to verify `tryNative` resolution across Deno, Bun, and standard Node.js environments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Native loading is now enabled by default in both Bun and Deno environments.

- **Bug Fixes**
  - Preserved existing environment-variable override behavior for native loading.

- **Tests**
  - Added coverage for Bun, Deno, and standard environments to verify native-loading defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->